### PR TITLE
feat: key events capture

### DIFF
--- a/Build_Release/keyboard-capture.js
+++ b/Build_Release/keyboard-capture.js
@@ -1,0 +1,90 @@
+/**
+ * Keyboard Capture for OpenClaw WASM
+ *
+ * Prevents browser/OS shortcuts from interfering with game controls.
+ * - Blocks Ctrl/Cmd + common shortcuts when game is focused
+ * - Blocks Alt + keys (macOS special characters)
+ * - Captures game keys and prevents default browser behavior
+ *
+ * Note: Ctrl + Arrow keys cannot be blocked (macOS Spaces navigation
+ * is handled at the system level). Disable in System Settings if needed.
+ */
+
+(function() {
+  'use strict';
+
+  var canvas = document.getElementById("canvas");
+  if (!canvas) return;
+
+  // Keys that should always be captured by the game when canvas is focused
+  var gameKeys = [
+    'Control', 'Alt', 'Shift', 'Meta',
+    'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+    'Space', 'Enter', 'Escape', 'Tab',
+    'KeyA', 'KeyS', 'KeyD', 'KeyW', 'KeyZ', 'KeyX', 'KeyC',
+    'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5',
+    'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12'
+  ];
+
+  // Shortcuts that should be blocked when the game is active
+  function shouldBlockShortcut(e) {
+    // Block Ctrl/Cmd + common shortcuts that conflict with game
+    if (e.ctrlKey || e.metaKey) {
+      var blockedWithModifier = ['KeyC', 'KeyV', 'KeyX', 'KeyZ', 'KeyA', 'KeyS', 'KeyW', 'KeyQ', 'KeyR', 'KeyT'];
+      if (blockedWithModifier.indexOf(e.code) !== -1) return true;
+    }
+    // Block Alt + keys on macOS (special characters)
+    if (e.altKey && !e.ctrlKey && !e.metaKey) {
+      return true;
+    }
+    return false;
+  }
+
+  function handleKeyEvent(e) {
+    // Only intercept when canvas has focus or game container is active
+    var isGameFocused = document.activeElement === canvas ||
+                        document.activeElement === document.body ||
+                        canvas.contains(document.activeElement);
+
+    if (!isGameFocused) return;
+
+    // Always let F11 through for browser fullscreen toggle
+    if (e.code === 'F11') return;
+
+    // Block system shortcuts that conflict with game controls
+    if (shouldBlockShortcut(e)) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
+    // For game keys, prevent default browser behavior
+    if (gameKeys.indexOf(e.code) !== -1 || gameKeys.indexOf(e.key) !== -1) {
+      e.preventDefault();
+    }
+  }
+
+  // Use capture phase to intercept before other handlers
+  document.addEventListener('keydown', handleKeyEvent, true);
+  document.addEventListener('keyup', handleKeyEvent, true);
+
+  // Ensure canvas can receive focus
+  canvas.tabIndex = 0;
+
+  // Auto-focus canvas when clicked
+  canvas.addEventListener('click', function() {
+    canvas.focus();
+  });
+
+  // Focus canvas when game container is clicked
+  var gameContainer = document.getElementById('gameContainer');
+  if (gameContainer) {
+    gameContainer.addEventListener('click', function(e) {
+      if (e.target !== canvas) {
+        canvas.focus();
+      }
+    });
+  }
+
+  console.log('[Keyboard] Game key interceptor enabled');
+})();

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -776,14 +776,28 @@
       };
 
       // Smart fullscreen function - always fullscreens the game container
+      // Uses Keyboard Lock API to capture ESC key in fullscreen (Chrome/Edge)
       function toggleFullscreen() {
         var gameContainer = document.getElementById("gameContainer");
         if (gameContainer) {
           if (!document.fullscreenElement) {
-            gameContainer.requestFullscreen().catch(function (err) {
+            gameContainer.requestFullscreen().then(function() {
+              // Request keyboard lock to capture ESC and system keys
+              if (navigator.keyboard && navigator.keyboard.lock) {
+                navigator.keyboard.lock(['Escape']).then(function() {
+                  console.log('[Keyboard] Locked ESC key in fullscreen');
+                }).catch(function(err) {
+                  console.log('[Keyboard] Could not lock ESC:', err.message);
+                });
+              }
+            }).catch(function (err) {
               console.error("Fullscreen request failed:", err);
             });
           } else {
+            // Unlock keyboard before exiting fullscreen
+            if (navigator.keyboard && navigator.keyboard.unlock) {
+              navigator.keyboard.unlock();
+            }
             document.exitFullscreen();
           }
         }
@@ -807,6 +821,10 @@
           if (btn) {
             btn.textContent = "⛶";
             btn.title = "Enter Fullscreen";
+          }
+          // Release keyboard lock when leaving fullscreen
+          if (navigator.keyboard && navigator.keyboard.unlock) {
+            navigator.keyboard.unlock();
           }
         }
 
@@ -948,6 +966,9 @@
 
     <!-- Main ES Module - loads all dependencies and exposes functions to window -->
     <script type="module" src="game-init.js"></script>
+
+    <!-- Keyboard capture - prevents OS shortcuts from interfering with game -->
+    <script src="keyboard-capture.js"></script>
 
     <!-- Initialize game after modules are loaded -->
     <script>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Browser-based version of the classic platformer. Based on [OpenClaw](https://git
 | Change Weapon | Left Shift or E |
 | Pause | Escape |
 
+The game captures keyboard input to prevent browser and OS shortcuts (like Ctrl+C, Alt+Tab) from interfering with gameplay. ESC is also captured in fullscreen mode (Chrome/Edge only).
+
+**macOS Note:** Ctrl + Arrow keys trigger Spaces navigation at the system level and cannot be blocked by the browser. To disable: System Settings → Keyboard → Keyboard Shortcuts → Mission Control → uncheck "Move left/right a space".
+
 ### Gamepad
 
 Xbox, PlayStation, and most standard controllers supported. See [Gamepad Support](docs/player/GAMEPAD.md) for button mapping and vibration feedback.


### PR DESCRIPTION
Implements keyboard capture to prevent OS shortcuts during gameplay. Works best when running on Chrome/Chromium browsers.

**macOS Note:** `Ctrl` + `Arrow` keys trigger Spaces navigation at the system level and cannot be blocked by the browser. To disable: **System Settings → Keyboard → Keyboard Shortcuts → Mission Control → uncheck** "Move left/right a space".

Closes #12 and #14