### PR TITLE
feat: add Vercel deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "outputDirectory": "Build_Release",
+  "public": false
+}


### PR DESCRIPTION
Enable branch previews on Vercel for easier testing across devices. Serves pre-built artifacts from `Build_Release/` with zero build overhead since WASM binaries are committed locally.

- Add `vercel.json` configuration
- Skip build step on Vercel (uses committed artifacts)
- Deploy all branches as shareable HTTPS previews (important for testing Fullscreen or Keyboard events while developing)