### PR TITLE
feat: installable game (PWA)

### DIFF
--- a/Build_Release/asset-loader.js
+++ b/Build_Release/asset-loader.js
@@ -67,8 +67,12 @@ function validateClawRezFile() {
     }
   }
 
-  // File is valid, enable upload button
+  // File is valid, enable upload button and reflect it in the drop zone
   uploadBtn.disabled = false;
+  var drop = document.getElementById('fileDrop');
+  var name = document.getElementById('fileDropName');
+  if (drop) drop.classList.add('has-file');
+  if (name) name.textContent = file.name + ' ✓';
   return true;
 }
 

--- a/Build_Release/asset-loader.js
+++ b/Build_Release/asset-loader.js
@@ -239,7 +239,16 @@ async function uploadClawRez() {
       }
     }
 
-    alert(`Upload failed: ${error.message}`);
+    // IndexedDB is disabled or quota-limited in some browsers' private/
+    // incognito modes, which is the most common cause of storage failures.
+    var failMsg = `Upload failed: ${error.message}`;
+    var errName = (error && error.name) || '';
+    if (/Quota|Security|InvalidState|Unknown/i.test(errName) ||
+        /quota|storage|indexeddb|database/i.test((error && error.message) || '')) {
+      failMsg += '\n\nTip: private / incognito browsing often blocks local '
+               + 'storage. Try again in a normal browser window.';
+    }
+    alert(failMsg);
 
     // Reset UI
     progressDiv.style.display = 'none';

--- a/Build_Release/asset-loader.js
+++ b/Build_Release/asset-loader.js
@@ -31,48 +31,83 @@ function hideAssetUpload() {
 /**
  * Validate CLAW.REZ file selection and enable/disable upload button
  */
-function validateClawRezFile() {
+// CLAW.REZ is a Monolith resource archive. Known-valid releases carry one of
+// two header signatures near the start (confirmed against original discs):
+//   - "RezMgr Version 1"  (118,033,115 bytes)
+//   - "WinRez 2.4"         (119,321,886 bytes)
+// A commonly mis-uploaded file carries "WinRez LT 3.0" and is only ~168 bytes,
+// so the size gate rejects it — but we also reject the "LT" signature outright.
+const REZ_VALID_SIGNATURES = ['RezMgr Version 1', 'WinRez 2.4'];
+const REZ_MIN_SIZE = 100 * 1024 * 1024; // ~100MB; real files are ~113MB
+const REZ_MAX_SIZE = 130 * 1024 * 1024; // generous upper bound
+
+function rejectRezFile(message) {
+  const fileInput = document.getElementById('clawRezFile');
+  const uploadBtn = document.getElementById('uploadBtn');
+  const drop = document.getElementById('fileDrop');
+  const name = document.getElementById('fileDropName');
+  if (fileInput) fileInput.value = '';
+  if (uploadBtn) uploadBtn.disabled = true;
+  if (drop) drop.classList.remove('has-file');
+  if (name) name.textContent = '';
+  alert(message);
+}
+
+function acceptRezFile(file) {
+  const uploadBtn = document.getElementById('uploadBtn');
+  const drop = document.getElementById('fileDrop');
+  const name = document.getElementById('fileDropName');
+  if (uploadBtn) uploadBtn.disabled = false;
+  if (drop) drop.classList.add('has-file');
+  if (name) name.textContent = file.name + ' ✓';
+}
+
+// Read the header and confirm it carries one of the known-valid signatures.
+async function hasRezSignature(file) {
+  try {
+    const head = await file.slice(0, 64).arrayBuffer();
+    const text = new TextDecoder('latin1').decode(new Uint8Array(head));
+    return REZ_VALID_SIGNATURES.some(function (sig) { return text.indexOf(sig) !== -1; });
+  } catch (e) {
+    console.error('Failed to read CLAW.REZ header:', e);
+    return false;
+  }
+}
+
+// Validate the selected file. Hard-rejects anything that is not a real
+// CLAW.REZ (wrong name, empty, wildly wrong size, or missing the RezMgr
+// signature) — no "continue anyway" escape hatch. Async: enables the upload
+// button only after the header check passes.
+async function validateClawRezFile() {
   const fileInput = document.getElementById('clawRezFile');
   const uploadBtn = document.getElementById('uploadBtn');
   const file = fileInput.files[0];
 
-  if (!file) {
-    uploadBtn.disabled = true;
-    return false;
-  }
+  if (uploadBtn) uploadBtn.disabled = true;
+  if (!file) return false;
 
-  // Validate file name (case-insensitive) - must be exactly CLAW.REZ
   if (!file.name.match(/^CLAW\.REZ$/i)) {
-    alert('Error: File must be named CLAW.REZ (case-insensitive)\n\nYou selected: ' + file.name);
-    fileInput.value = ''; // Clear the selection
-    uploadBtn.disabled = true;
+    rejectRezFile('That file is not CLAW.REZ.\n\nThe file must be named CLAW.REZ (from the original Captain Claw game).\n\nYou selected: ' + file.name);
     return false;
   }
 
-  // Validate file size (approximately 113MB)
-  const expectedSize = 113 * 1024 * 1024; // 113MB
-  const tolerance = 10 * 1024 * 1024; // 10MB tolerance
-  const sizeMB = (file.size / 1024 / 1024).toFixed(2);
-
-  if (Math.abs(file.size - expectedSize) > tolerance) {
-    const proceed = window.confirm(
-      `Warning: File size is ${sizeMB}MB. Expected ~113MB.\n\n` +
-      `This might not be the correct CLAW.REZ file.\n\n` +
-      `Continue anyway?`
-    );
-    if (!proceed) {
-      fileInput.value = ''; // Clear the selection
-      uploadBtn.disabled = true;
-      return false;
-    }
+  if (file.size === 0) {
+    rejectRezFile('That file is empty.\n\nPlease select the real CLAW.REZ from the original Captain Claw (1997) game.');
+    return false;
   }
 
-  // File is valid, enable upload button and reflect it in the drop zone
-  uploadBtn.disabled = false;
-  var drop = document.getElementById('fileDrop');
-  var name = document.getElementById('fileDropName');
-  if (drop) drop.classList.add('has-file');
-  if (name) name.textContent = file.name + ' ✓';
+  const sizeMB = (file.size / 1024 / 1024).toFixed(1);
+  if (file.size < REZ_MIN_SIZE || file.size > REZ_MAX_SIZE) {
+    rejectRezFile('That does not look like CLAW.REZ.\n\nIts size is ' + sizeMB + 'MB but CLAW.REZ is about 113MB. Please select the correct file from the original Captain Claw (1997) game.');
+    return false;
+  }
+
+  if (!(await hasRezSignature(file))) {
+    rejectRezFile('That file is not a valid CLAW.REZ.\n\nIt is missing the expected archive header. Please select the correct CLAW.REZ from the original Captain Claw (1997) game.');
+    return false;
+  }
+
+  acceptRezFile(file);
   return true;
 }
 

--- a/Build_Release/game-init.js
+++ b/Build_Release/game-init.js
@@ -46,16 +46,21 @@ function prewarmAudioContext() {
 }
 
 function waitForStartClick() {
+  // Reveals the in-game controls (.bottom-controls, touch install button),
+  // which stay hidden until the start overlay is gone so their clicks can't
+  // fall through to the overlay and start the game prematurely.
+  const markStarted = () => document.body.classList.add('game-started');
   return new Promise((resolve) => {
     if (window.audioContext && window.audioContext.state === 'running') {
-      resolve(); return;
+      markStarted(); resolve(); return;
     }
     const overlay = document.getElementById('startOverlay');
-    if (!overlay) { resolve(); return; }
+    if (!overlay) { markStarted(); resolve(); return; }
     overlay.style.display = 'flex';
     window._startOverlayClick = function() {
       prewarmAudioContext();
       overlay.style.display = 'none';
+      markStarted();
       window._startOverlayClick = null;
       resolve();
     };
@@ -72,10 +77,53 @@ async function checkClawRezCached() {
   }
 }
 
+// Show the install onboarding screen once, before first-run upload. Resolves
+// when the user chooses Install or Not now (or immediately if not applicable).
+function runInstallOnboarding() {
+  return new Promise((resolve) => {
+    var api = window.OpenClawInstall;
+    var screen = document.getElementById('installScreen');
+    var SEEN_KEY = 'pwa_install_onboarded';
+
+    // Skip if: no API, already installed, or the user already saw this screen.
+    if (!api || api.isInstalled || !screen || localStorage.getItem(SEEN_KEY)) {
+      resolve(); return;
+    }
+
+    var badge = document.getElementById('installBadge');
+    var reason = document.getElementById('installReason');
+    var yesBtn = document.getElementById('installYesBtn');
+    var skipBtn = document.getElementById('installSkipBtn');
+    var rec = api.recommendation || { level: 'optional', reason: '' };
+
+    if (badge) {
+      badge.textContent = rec.level === 'recommended' ? 'Recommended' : 'Optional';
+      badge.classList.add(rec.level === 'recommended' ? 'recommended' : 'optional');
+    }
+    if (reason) reason.textContent = rec.reason;
+
+    function finish() {
+      localStorage.setItem(SEEN_KEY, '1');
+      screen.classList.remove('visible');
+      resolve();
+    }
+
+    if (yesBtn) yesBtn.addEventListener('click', function () {
+      Promise.resolve(api.trigger()).then(finish);
+    });
+    if (skipBtn) skipBtn.addEventListener('click', finish);
+
+    screen.classList.add('visible');
+  });
+}
+
 // Initialize game (called from inline script)
 window.initGameWhenReady = async function() {
 
   try {
+    // Offer install before first-run upload (once, when applicable).
+    await runInstallOnboarding();
+
     const hasCached = await checkClawRezCached();
 
     let success;

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -700,6 +700,22 @@
         </div>
       </div>
     </section>
+
+    <!-- Load-failure recovery: shown if the WASM runtime aborts or the game
+         never starts (usually a wrong/corrupt CLAW.REZ that passed the size
+         check). Lets the user clear the stored file and re-upload. -->
+    <section id="loadError" class="onboard">
+      <div class="onboard-card">
+        <div class="onboard-emoji">⚠️</div>
+        <h2>Game failed to load</h2>
+        <p>This usually means the uploaded <strong>CLAW.REZ</strong> is not the
+           correct file from Captain Claw (1997), or it was corrupted.</p>
+        <div class="onboard-actions">
+          <button class="btn btn-primary" id="loadErrorClearBtn">Clear file &amp; re-upload</button>
+          <button class="btn btn-ghost" id="loadErrorReloadBtn">Reload</button>
+        </div>
+      </div>
+    </section>
     <div class="debug_panel" style="display: none">
       <div class="cheats">
         <div>
@@ -1081,6 +1097,12 @@
 
       // Emscripten structure
       var Module = {
+        // If the WASM runtime aborts (e.g. bad CLAW.REZ that passed the size
+        // check), surface the recovery overlay instead of a dead black screen.
+        onAbort: function (what) {
+          console.error('[Game] Aborted:', what);
+          if (window.showLoadError) window.showLoadError();
+        },
         // Canvas dimensions are dynamic based on fullscreen state
         // Default: 640x480 (4:3), Fullscreen: calculated from screen aspect ratio
         preRun: [
@@ -1092,6 +1114,7 @@
                 console.error('Failed to mount CLAW.REZ');
               }
             }
+            if (window.startLoadWatchdog) window.startLoadWatchdog();
 
             // Set initial canvas dimensions (may be overridden by fullscreen)
             var canvas = Module.canvas;
@@ -1105,6 +1128,7 @@
         ],
         postRun: [
           function () {
+            if (window.markGameRunning) window.markGameRunning();
             // Disable Emscripten's automatic canvas resizing
             if (typeof Browser !== 'undefined') {
               Browser.resizeCanvas = false;
@@ -1398,6 +1422,50 @@
           recommendation: recommendation(),
           trigger: trigger
         };
+      })();
+    </script>
+
+    <!-- Load-failure recovery controller -->
+    <script>
+      (function () {
+        var overlay = document.getElementById('loadError');
+        var shown = false;
+        var watchdog = null;
+
+        window.showLoadError = function () {
+          if (shown) return;
+          shown = true;
+          if (watchdog) { clearTimeout(watchdog); watchdog = null; }
+          if (overlay) overlay.classList.add('visible');
+        };
+
+        // Backstop: if the game hasn't reported a running frame within 20s of
+        // the module starting, assume it hung on a bad file and offer recovery.
+        window.startLoadWatchdog = function () {
+          if (watchdog || shown) return;
+          watchdog = setTimeout(function () {
+            if (!window.__openClawRunning) window.showLoadError();
+          }, 20000);
+        };
+        // The game sets this once it is actually rendering (postRun); if that
+        // never happens, the watchdog fires.
+        window.markGameRunning = function () {
+          window.__openClawRunning = true;
+          if (watchdog) { clearTimeout(watchdog); watchdog = null; }
+        };
+
+        var clearBtn = document.getElementById('loadErrorClearBtn');
+        var reloadBtn = document.getElementById('loadErrorReloadBtn');
+        if (clearBtn) clearBtn.addEventListener('click', function () {
+          if (typeof window.reuploadClawRez === 'function') {
+            window.reuploadClawRez();
+          } else {
+            location.reload();
+          }
+        });
+        if (reloadBtn) reloadBtn.addEventListener('click', function () {
+          location.reload();
+        });
       })();
     </script>
 

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -89,6 +89,15 @@
         display: flex;
         align-items: center;
         justify-content: center;
+        /* Keep the canvas clear of the notch/Dynamic Island/home indicator in
+           both orientations. box-sizing:border-box so the padding shrinks the
+           inner area rather than overflowing. */
+        box-sizing: border-box;
+        padding:
+          env(safe-area-inset-top, 0px)
+          env(safe-area-inset-right, 0px)
+          env(safe-area-inset-bottom, 0px)
+          env(safe-area-inset-left, 0px);
       }
 
       .game-header {
@@ -1049,6 +1058,19 @@
         }
       });
       window.addEventListener("resize", updateGameResolution);
+
+      // Orientation change on iOS reports stale viewport dimensions during the
+      // resize event (dimensions settle a frame or two later), which leaves the
+      // canvas fitted to the OLD orientation and looking zoomed. Re-apply after
+      // the viewport settles. visualViewport.resize is the most reliable signal.
+      window.addEventListener("orientationchange", function () {
+        updateGameResolution();
+        setTimeout(updateGameResolution, 100);
+        setTimeout(updateGameResolution, 300);
+      });
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", updateGameResolution);
+      }
 
       // Initialize resolution on load
       updateGameResolution();

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1295,8 +1295,13 @@
         var desktopBtn = document.getElementById('pwa-install-control');
         var deferredPrompt = null;
 
+        // Evaluated once at load, before the game can invoke the Fullscreen
+        // API — so display-mode: fullscreen here means the app was LAUNCHED as
+        // an installed PWA (manifest uses display: fullscreen), not a tab that
+        // toggled fullscreen. Both fullscreen and standalone indicate installed.
         var isStandalone =
           window.matchMedia('(display-mode: standalone)').matches ||
+          window.matchMedia('(display-mode: fullscreen)').matches ||
           window.navigator.standalone === true;
 
         var ua = navigator.userAgent;

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -201,9 +201,16 @@
         bottom: 1%;
         right: 1%;
         z-index: 1000;
-        display: flex;
+        display: none;
         gap: clamp(5px, 1cqw, 10px);
         align-items: center;
+      }
+      /* Controls appear only after the player dismisses the start overlay.
+         The overlay is a full-screen z-index:10000 layer; showing the controls
+         (z-index:1000) beneath it earlier let their clicks fall through and
+         start the game. */
+      body.game-started .bottom-controls {
+        display: flex;
       }
 
       /* Delay button appearance only when intro video is playing */
@@ -314,91 +321,23 @@
       }
 
       /* Asset Upload UI */
-      #assetUpload {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, 0.95);
-        z-index: 10000;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        color: #fff;
-        padding: 20px;
-      }
-
-      #assetUpload h2 {
-        font-size: 2em;
-        margin-bottom: 15px;
-        color: #fff;
-        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-        max-width: 600px;
-      }
-
-      #assetUpload p {
-        font-size: 1.1em;
-        margin: 10px 0;
-        max-width: 600px;
-        line-height: 1.6;
-      }
-
-      #assetUpload strong {
-        color: #4db8ff;
-        font-weight: 600;
-      }
+      /* CLAW.REZ strong text accent (used inside the onboarding card) */
+      #assetUpload strong { color: #e23b2e; font-weight: 600; }
+      /* Left-align body copy on the upload screen (title stays centered) */
+      #assetUpload p { text-align: left; }
 
       #uploadArea {
-        margin-top: 30px;
+        margin-top: 18px;
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 15px;
+        gap: 12px;
       }
 
-      #clawRezFile {
-        padding: 10px;
-        font-size: 1em;
-        border: 2px solid rgba(77, 184, 255, 0.5);
-        border-radius: 5px;
-        background-color: rgba(255, 255, 255, 0.1);
-        color: #fff;
-        cursor: pointer;
-      }
-
-      #uploadArea button {
-        padding: 12px 30px;
-        font-size: 1.1em;
-        font-weight: bold;
-        color: #fff;
-        background-color: #4db8ff;
-        border: none;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: all 0.2s;
-      }
-
-      #uploadArea button:hover {
-        background-color: #66c2ff;
-        transform: scale(1.05);
-      }
-
-      #uploadArea button:active {
-        transform: scale(0.98);
-      }
-
-      #uploadArea button:disabled {
-        background-color: #666;
-        color: #999;
+      #uploadBtn:disabled {
+        background: #3a4250;
+        color: #7b828c;
         cursor: not-allowed;
-        opacity: 0.5;
-      }
-
-      #uploadArea button:disabled:hover {
-        background-color: #666;
-        transform: none;
       }
 
       #uploadProgress {
@@ -407,26 +346,28 @@
       }
 
       #uploadProgressBar {
-        width: 400px;
-        height: 30px;
-        border-radius: 5px;
+        width: 220px;
+        max-width: 80%;
+        height: 3px;
+        border-radius: 999px;
         overflow: hidden;
-        background-color: rgba(255, 255, 255, 0.1);
+        border: none;
+        background-color: rgba(255, 255, 255, 0.15);
       }
 
       #uploadProgressBar::-webkit-progress-bar {
-        background-color: rgba(255, 255, 255, 0.1);
-        border-radius: 5px;
+        background-color: rgba(255, 255, 255, 0.15);
+        border-radius: 999px;
       }
 
       #uploadProgressBar::-webkit-progress-value {
-        background-color: #4db8ff;
-        border-radius: 5px;
+        background-color: #e23b2e;
+        border-radius: 999px;
       }
 
       #uploadProgressBar::-moz-progress-bar {
-        background-color: #4db8ff;
-        border-radius: 5px;
+        background-color: #e23b2e;
+        border-radius: 999px;
       }
 
       #uploadStatus {
@@ -492,69 +433,122 @@
         opacity: 1;
       }
 
-      /* PWA install prompt — compact card, bottom-right on wide screens.
-         Sits above #startOverlay (z-index 10000); a capture-phase JS guard also
-         stops clicks from reaching the overlay / game input listeners. */
-      #pwa-install-banner {
-        display: none;
+      /* Floating install button for touch devices only */
+      /* ---- Onboarding screens (install prompt + asset upload) ---- */
+      .onboard {
         position: fixed;
-        bottom: 16px;
-        right: 16px;
-        left: auto;
-        z-index: 10001;
-        max-width: min(560px, calc(100vw - 32px));
-        background: rgba(0, 0, 0, 0.92);
-        color: #fff;
-        padding: 12px 14px;
-        flex-wrap: wrap;
+        inset: 0;
+        z-index: 10000;
+        display: none;
+        flex-direction: column;
         align-items: center;
+        justify-content: center;
+        gap: 22px;
+        padding: 24px;
+        background: radial-gradient(circle at 50% 30%, #1a2230 0%, #0a0d12 70%);
+        color: #fff;
+        text-align: center;
+      }
+      .onboard.visible { display: flex; }
+      .onboard .onboard-card {
+        width: 100%;
+        max-width: 440px;
+        background: rgba(255,255,255,0.04);
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: 16px;
+        padding: 28px 26px;
+        box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+      }
+      .onboard .onboard-emoji { font-size: 44px; line-height: 1; }
+      .onboard h2 {
+        margin: 14px 0 6px;
+        font-size: 1.5em;
+        color: #fff;
+      }
+      .onboard .onboard-badge {
+        display: inline-block;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        text-transform: uppercase;
+        padding: 3px 10px;
+        border-radius: 999px;
+        margin-bottom: 12px;
+      }
+      .onboard .onboard-badge.recommended {
+        background: rgba(82, 196, 26, 0.18); color: #7ee06a;
+        border: 1px solid rgba(82,196,26,0.4);
+      }
+      .onboard .onboard-badge.optional {
+        background: rgba(255,255,255,0.1); color: #bbb;
+        border: 1px solid rgba(255,255,255,0.2);
+      }
+      .onboard p {
+        margin: 8px 0;
+        font-size: 0.98em;
+        line-height: 1.55;
+        color: #cdd3db;
+      }
+      .onboard .onboard-actions {
+        display: flex;
+        flex-direction: column;
         gap: 10px;
-        font-size: 14px;
-        border: 1px solid rgba(255,255,255,0.15);
+        margin-top: 22px;
+      }
+      .onboard .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 13px 20px;
+        font-size: 1em;
+        font-weight: 600;
+        border: none;
+        border-radius: 10px;
+        cursor: pointer;
+        transition: transform 0.15s ease, background 0.2s ease;
+      }
+      .onboard .btn:active { transform: scale(0.98); }
+      .onboard .btn-primary { background: #e23b2e; color: #fff; }
+      .onboard .btn-primary:hover { background: #c62f24; }
+      .onboard .btn-ghost {
+        background: transparent; color: #aab2bd;
+        border: 1px solid rgba(255,255,255,0.18);
+      }
+      .onboard .btn-ghost:hover { background: rgba(255,255,255,0.06); color: #fff; }
+      .onboard .onboard-legal {
+        margin-top: 20px;
+        font-size: 11px;
+        color: #6b7280;
+        line-height: 1.5;
+        max-width: 420px;
+      }
+
+      /* Custom file picker for the upload screen */
+      .file-drop {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 22px 16px;
+        margin: 4px 0 6px;
+        border: 2px dashed rgba(226,59,46,0.5);
         border-radius: 12px;
-        box-shadow: 0 6px 24px rgba(0,0,0,0.45);
+        background: rgba(226,59,46,0.07);
+        color: #cdd3db;
+        cursor: pointer;
+        transition: border-color 0.2s ease, background 0.2s ease;
       }
-      #pwa-install-banner.visible { display: flex; }
-      #pwa-install-banner .pwa-icon { font-size: 24px; flex: 0 0 auto; }
-      /* Text grows and may shrink; min-width:0 lets it truncate instead of
-         pushing the buttons off the card. */
-      #pwa-install-banner .pwa-text { flex: 1 1 180px; line-height: 1.35; min-width: 0; }
-      #pwa-install-banner .pwa-text strong {
-        display: block; font-size: 13px;
-        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      .file-drop:hover { border-color: rgba(226,59,46,0.9); background: rgba(226,59,46,0.14); }
+      .file-drop.has-file { border-style: solid; border-color: #52c41a; background: rgba(82,196,26,0.1); }
+      .file-drop .file-drop-icon { font-size: 30px; }
+      .file-drop .file-drop-label { font-size: 0.95em; }
+      .file-drop .file-drop-name { font-size: 0.82em; color: #7ee06a; word-break: break-all; }
+      .file-drop input[type="file"] {
+        position: absolute; width: 1px; height: 1px; opacity: 0; overflow: hidden;
       }
-      #pwa-install-banner .pwa-text small {
-        display: block; color: #aaa; font-size: 12px;
-        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-      }
-      #pwa-install-banner .pwa-actions { display: flex; gap: 6px; flex: 0 0 auto; margin-left: auto; }
-      #pwa-install-banner button {
-        border: none; border-radius: 6px; padding: 7px 12px;
-        font-size: 13px; cursor: pointer; font-weight: 600; white-space: nowrap;
-      }
-      #pwa-install-banner .btn-install {
-        background: var(--primary-color); color: #fff;
-      }
-      #pwa-install-banner .btn-dismiss {
-        background: rgba(255,255,255,0.12); color: #ccc;
-      }
-      /* Narrow screens: stretch to a bottom bar and drop the buttons onto a
-         full-width second row so they never overlap the text. */
-      @media (max-width: 480px) {
-        #pwa-install-banner {
-          left: 12px;
-          right: 12px;
-          bottom: 12px;
-          max-width: none;
-        }
-        #pwa-install-banner .pwa-text { flex: 1 1 auto; }
-        #pwa-install-banner .pwa-actions {
-          flex: 1 1 100%;
-          margin-left: 0;
-          justify-content: flex-end;
-        }
-        #pwa-install-banner .pwa-actions button { flex: 1 1 auto; }
-      }
+
     </style>
   </head>
   <body>
@@ -580,21 +574,30 @@
       </svg>
     </div>
 
-    <!-- Asset Upload UI (shown on first run) -->
-    <section id="assetUpload" style="display: none;">
-      <h2>First Time Setup</h2>
-      <p>OpenClaw requires <strong>CLAW.REZ</strong> from the original Captain Claw (1997) game.</p>
-      <p><strong>Legal Notice:</strong> You must own Captain Claw (1997) to use this file legally.</p>
-      <p>The file will be stored in your browser's local storage and only needs to be uploaded once.</p>
+    <!-- Asset Upload UI (shown after the install screen, on first run) -->
+    <section id="assetUpload" class="onboard">
+      <div class="onboard-card">
+        <div class="onboard-emoji">📦</div>
+        <h2>One-time setup</h2>
+        <p>The game requires <strong>CLAW.REZ</strong> from the original Captain Claw (1997) game.</p>
+        <p>The file only needs to be uploaded once.</p>
 
-      <div id="uploadArea">
-        <input type="file" id="clawRezFile" accept=".REZ,.rez" onchange="validateClawRezFile()" />
-        <button id="uploadBtn" onclick="uploadClawRez()" disabled>Upload CLAW.REZ</button>
-      </div>
+        <div id="uploadArea">
+          <label class="file-drop" id="fileDrop" for="clawRezFile">
+            <span class="file-drop-icon">📁</span>
+            <span class="file-drop-label">Choose or drop your CLAW.REZ file</span>
+            <span class="file-drop-name" id="fileDropName"></span>
+            <input type="file" id="clawRezFile" accept=".REZ,.rez" onchange="validateClawRezFile()" />
+          </label>
+          <button class="btn btn-primary" id="uploadBtn" onclick="uploadClawRez()" disabled>Upload CLAW.REZ</button>
+        </div>
 
-      <div id="uploadProgress" style="display: none;">
-        <progress id="uploadProgressBar" max="100" value="0"></progress>
-        <span id="uploadStatus">Storing assets...</span>
+        <div id="uploadProgress" style="display: none;">
+          <progress id="uploadProgressBar" max="100" value="0"></progress>
+          <span id="uploadStatus">Storing assets...</span>
+        </div>
+
+        <p class="onboard-legal">You must own Captain Claw (1997) to use this file legally.</p>
       </div>
     </section>
 
@@ -641,6 +644,15 @@
           <div class="bottom-controls">
             <button
               class="control-btn"
+              id="pwa-install-control"
+              title="Install App"
+              aria-label="Install OpenClaw"
+              style="display: none"
+            >
+              ⬇
+            </button>
+            <button
+              class="control-btn"
               id="fullscreenBtn"
               onclick="toggleFullscreen()"
               title="Enter Fullscreen"
@@ -651,18 +663,19 @@
         </div>
       </div>
     </div>
-    <!-- PWA install banner — shown to mobile users not yet running in standalone mode -->
-    <div id="pwa-install-banner" role="banner" aria-label="Install OpenClaw">
-      <span class="pwa-icon">🎮</span>
-      <div class="pwa-text">
-        <strong>Add OpenClaw to your Home Screen</strong>
-        <small>Play fullscreen, no browser chrome</small>
+    <!-- Install onboarding screen (shown first, before upload, when installable) -->
+    <section id="installScreen" class="onboard">
+      <div class="onboard-card">
+        <div class="onboard-emoji">🎮</div>
+        <span id="installBadge" class="onboard-badge">&nbsp;</span>
+        <h2>Install OpenClaw?</h2>
+        <p id="installReason">Install OpenClaw for the best experience.</p>
+        <div class="onboard-actions">
+          <button class="btn btn-primary" id="installYesBtn">⬇ Install OpenClaw</button>
+          <button class="btn btn-ghost" id="installSkipBtn">Not now</button>
+        </div>
       </div>
-      <div class="pwa-actions">
-        <button class="btn-install" id="pwa-install-btn">Install</button>
-        <button class="btn-dismiss" id="pwa-dismiss-btn">Later</button>
-      </div>
-    </div>
+    </section>
     <div class="debug_panel" style="display: none">
       <div class="cheats">
         <div>
@@ -1238,62 +1251,62 @@
         throw new Error('Browser not supported');
       }
     </script>
-    <!-- PWA install prompt logic -->
+    <!-- PWA install: shared API used by the onboarding screen and the
+         persistent install buttons (desktop toolbar + touch floating). -->
     <script>
       (function () {
-        var banner = document.getElementById('pwa-install-banner');
-        var installBtn = document.getElementById('pwa-install-btn');
-        var dismissBtn = document.getElementById('pwa-dismiss-btn');
-        var textEl = banner.querySelector('.pwa-text small');
+        var desktopBtn = document.getElementById('pwa-install-control');
         var deferredPrompt = null;
-        var DISMISS_KEY = 'pwa_install_dismissed';
 
-        // Detect an already-installed PWA. Note: display-mode: fullscreen is
-        // deliberately NOT checked — it also matches the Fullscreen API, which
-        // this game uses, and would suppress the banner during normal play.
         var isStandalone =
           window.matchMedia('(display-mode: standalone)').matches ||
           window.navigator.standalone === true;
 
-        if (isStandalone || localStorage.getItem(DISMISS_KEY)) return;
-
         var ua = navigator.userAgent;
         var isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
-        // Safari = has Safari token but is not Chrome/Chromium/Edge/Firefox-iOS.
+        var isAndroid = /Android/.test(ua);
         var isSafari =
           /Safari/.test(ua) && !/Chrome|Chromium|Edg|CriOS|FxiOS|OPR/.test(ua);
         var isIOSSafari = isIOS && isSafari;
         var isMacSafari = isSafari && /Macintosh/.test(ua) && !isIOS;
 
-        function dismiss() {
-          banner.classList.remove('visible');
-          localStorage.setItem(DISMISS_KEY, '1');
+        // Why installing is (or isn't) worth it, tuned per platform. Mobile
+        // benefits most (fullscreen, home-screen launch); desktop is optional.
+        function recommendation() {
+          if (isIOSSafari) {
+            return {
+              level: 'recommended',
+              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch OpenClaw straight from your home screen.'
+            };
+          }
+          if (isAndroid) {
+            return {
+              level: 'recommended',
+              reason: 'On Android, installing gives you a real fullscreen, app-like experience launched from your home screen.'
+            };
+          }
+          return {
+            level: 'optional',
+            reason: 'On desktop, OpenClaw already runs great in the browser. Installing simply opens it in its own dedicated window.'
+          };
         }
 
-        // Capture the native install prompt if the browser offers one. This is
-        // an enhancement: Chrome/Edge usually fire it, but it is unreliable
-        // (some Chrome setups, localhost, and all of Safari/Firefox never do).
-        // The banner is shown unconditionally below regardless, so it must not
-        // depend on this event — if it fired, the Install button uses it.
-        window.addEventListener('beforeinstallprompt', function (e) {
-          e.preventDefault();
-          deferredPrompt = e;
-        });
+        function hideAllInstallUI() {
+          if (desktopBtn) desktopBtn.style.display = 'none';
+        }
 
-        window.addEventListener('appinstalled', dismiss);
-
-        installBtn.addEventListener('click', function () {
+        // Native prompt when available, else per-platform manual instructions.
+        // Returns a promise resolving true if a native install was accepted.
+        function trigger() {
           if (deferredPrompt) {
-            // One-click native install (Chrome/Edge when the event fired)
             deferredPrompt.prompt();
-            deferredPrompt.userChoice.then(function (result) {
+            return deferredPrompt.userChoice.then(function (result) {
               deferredPrompt = null;
-              banner.classList.remove('visible');
-              if (result.outcome === 'accepted') {
-                localStorage.setItem(DISMISS_KEY, '1');
-              }
+              if (result.outcome === 'accepted') hideAllInstallUI();
+              return result.outcome === 'accepted';
             });
-          } else if (isIOSSafari) {
+          }
+          if (isIOSSafari) {
             alert(
               'Install OpenClaw on iOS:\n\n' +
               '1. Tap the Share button at the bottom of Safari\n' +
@@ -1308,8 +1321,6 @@
               '3. Confirm — the game opens in its own window.'
             );
           } else {
-            // Any other browser with no native prompt (e.g. Chrome that didn't
-            // fire the event, Firefox). Point at the universal menu action.
             alert(
               'Install OpenClaw:\n\n' +
               'Open your browser menu and choose “Install app”,\n' +
@@ -1317,31 +1328,34 @@
               'The game will then open in its own fullscreen window.'
             );
           }
-        });
-
-        dismissBtn.addEventListener('click', dismiss);
-
-        // The start overlay and the game attach input listeners high in the
-        // tree. Stop events that originate inside the banner from bubbling up
-        // to them, so interacting with the banner never also starts the game.
-        // NOTE: bubble phase (not capture) — capturing here would swallow the
-        // event before it reached the banner's own buttons.
-        ['click', 'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'touchstart', 'touchend'].forEach(
-          function (type) {
-            banner.addEventListener(type, function (e) { e.stopPropagation(); });
-          }
-        );
-
-        // Tailor the subtitle to the platform, then show the banner to every
-        // non-installed user. Install behaviour is handled by the button above.
-        if (textEl) {
-          if (isIOSSafari) {
-            textEl.textContent = 'Tap Share, then “Add to Home Screen”';
-          } else if (isMacSafari) {
-            textEl.textContent = 'File menu → “Add to Dock”';
-          }
+          return Promise.resolve(false);
         }
-        banner.classList.add('visible');
+
+        window.addEventListener('beforeinstallprompt', function (e) {
+          e.preventDefault();
+          deferredPrompt = e;
+        });
+        window.addEventListener('appinstalled', hideAllInstallUI);
+
+        // Persistent desktop button (bottom toolbar). The touch install
+        // button lives inside #touchControls and is wired in touch-controls.js.
+        if (!isStandalone && desktopBtn) {
+          desktopBtn.style.display = '';
+          desktopBtn.addEventListener('click', trigger);
+        }
+
+        // Public API for the onboarding flow (game-init.js).
+        window.OpenClawInstall = {
+          isInstalled: isStandalone,
+          platform: {
+            isIOSSafari: isIOSSafari,
+            isMacSafari: isMacSafari,
+            isAndroid: isAndroid,
+            isMobile: isIOS || isAndroid
+          },
+          recommendation: recommendation(),
+          trigger: trigger
+        };
       })();
     </script>
 

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1270,20 +1270,21 @@
           localStorage.setItem(DISMISS_KEY, '1');
         }
 
-        // The only programmatic install API. Chrome/Edge/Chromium-with-Google
-        // fire this; Safari and Firefox never do. When present, the Install
-        // button triggers the real one-click prompt; the banner is shown here
-        // (rather than up-front) so it only appears once install is possible.
+        // Capture the native install prompt if the browser offers one. This is
+        // an enhancement: Chrome/Edge usually fire it, but it is unreliable
+        // (some Chrome setups, localhost, and all of Safari/Firefox never do).
+        // The banner is shown unconditionally below regardless, so it must not
+        // depend on this event — if it fired, the Install button uses it.
         window.addEventListener('beforeinstallprompt', function (e) {
           e.preventDefault();
           deferredPrompt = e;
-          banner.classList.add('visible');
         });
 
         window.addEventListener('appinstalled', dismiss);
 
         installBtn.addEventListener('click', function () {
           if (deferredPrompt) {
+            // One-click native install (Chrome/Edge when the event fired)
             deferredPrompt.prompt();
             deferredPrompt.userChoice.then(function (result) {
               deferredPrompt = null;
@@ -1306,31 +1307,41 @@
               '2. Choose “Add to Dock…”\n' +
               '3. Confirm — the game opens in its own window.'
             );
+          } else {
+            // Any other browser with no native prompt (e.g. Chrome that didn't
+            // fire the event, Firefox). Point at the universal menu action.
+            alert(
+              'Install OpenClaw:\n\n' +
+              'Open your browser menu and choose “Install app”,\n' +
+              '“Add to Home Screen”, or “Create shortcut”.\n\n' +
+              'The game will then open in its own fullscreen window.'
+            );
           }
         });
 
         dismissBtn.addEventListener('click', dismiss);
 
-        // Belt-and-suspenders: the start overlay and the game attach input
-        // listeners high in the tree. Stop every pointer/click/touch event that
-        // originates inside the banner from bubbling up to them, so interacting
-        // with the banner never also starts the game.
+        // The start overlay and the game attach input listeners high in the
+        // tree. Stop events that originate inside the banner from bubbling up
+        // to them, so interacting with the banner never also starts the game.
+        // NOTE: bubble phase (not capture) — capturing here would swallow the
+        // event before it reached the banner's own buttons.
         ['click', 'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'touchstart', 'touchend'].forEach(
           function (type) {
-            banner.addEventListener(type, function (e) { e.stopPropagation(); }, true);
+            banner.addEventListener(type, function (e) { e.stopPropagation(); });
           }
         );
 
-        // Safari has no install event, so show the banner up-front there with
-        // platform-specific copy. Other browsers without the event (Firefox,
-        // plain Chromium) have no reliable install path, so no banner is shown.
-        if (isIOSSafari && textEl) {
-          textEl.textContent = 'Tap Share, then “Add to Home Screen”';
-          banner.classList.add('visible');
-        } else if (isMacSafari && textEl) {
-          textEl.textContent = 'File menu → “Add to Dock”';
-          banner.classList.add('visible');
+        // Tailor the subtitle to the platform, then show the banner to every
+        // non-installed user. Install behaviour is handled by the button above.
+        if (textEl) {
+          if (isIOSSafari) {
+            textEl.textContent = 'Tap Share, then “Add to Home Screen”';
+          } else if (isMacSafari) {
+            textEl.textContent = 'File menu → “Add to Dock”';
+          }
         }
+        banner.classList.add('visible');
       })();
     </script>
 

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -506,6 +506,7 @@
         background: rgba(0, 0, 0, 0.92);
         color: #fff;
         padding: 12px 14px;
+        flex-wrap: wrap;
         align-items: center;
         gap: 10px;
         font-size: 14px;
@@ -514,14 +515,22 @@
         box-shadow: 0 6px 24px rgba(0,0,0,0.45);
       }
       #pwa-install-banner.visible { display: flex; }
-      #pwa-install-banner .pwa-icon { font-size: 24px; flex-shrink: 0; }
-      #pwa-install-banner .pwa-text { flex: 1; line-height: 1.35; min-width: 0; white-space: nowrap; }
-      #pwa-install-banner .pwa-text strong { display: block; font-size: 13px; }
-      #pwa-install-banner .pwa-text small { color: #aaa; font-size: 12px; }
-      #pwa-install-banner .pwa-actions { display: flex; gap: 6px; flex-shrink: 0; }
+      #pwa-install-banner .pwa-icon { font-size: 24px; flex: 0 0 auto; }
+      /* Text grows and may shrink; min-width:0 lets it truncate instead of
+         pushing the buttons off the card. */
+      #pwa-install-banner .pwa-text { flex: 1 1 180px; line-height: 1.35; min-width: 0; }
+      #pwa-install-banner .pwa-text strong {
+        display: block; font-size: 13px;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      }
+      #pwa-install-banner .pwa-text small {
+        display: block; color: #aaa; font-size: 12px;
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      }
+      #pwa-install-banner .pwa-actions { display: flex; gap: 6px; flex: 0 0 auto; margin-left: auto; }
       #pwa-install-banner button {
         border: none; border-radius: 6px; padding: 7px 12px;
-        font-size: 13px; cursor: pointer; font-weight: 600;
+        font-size: 13px; cursor: pointer; font-weight: 600; white-space: nowrap;
       }
       #pwa-install-banner .btn-install {
         background: var(--primary-color); color: #fff;
@@ -529,7 +538,8 @@
       #pwa-install-banner .btn-dismiss {
         background: rgba(255,255,255,0.12); color: #ccc;
       }
-      /* Narrow screens: stretch to a bottom bar so the card never overflows */
+      /* Narrow screens: stretch to a bottom bar and drop the buttons onto a
+         full-width second row so they never overlap the text. */
       @media (max-width: 480px) {
         #pwa-install-banner {
           left: 12px;
@@ -537,6 +547,13 @@
           bottom: 12px;
           max-width: none;
         }
+        #pwa-install-banner .pwa-text { flex: 1 1 auto; }
+        #pwa-install-banner .pwa-actions {
+          flex: 1 1 100%;
+          margin-left: 0;
+          justify-content: flex-end;
+        }
+        #pwa-install-banner .pwa-actions button { flex: 1 1 auto; }
       }
     </style>
   </head>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -435,6 +435,9 @@
 
       /* Floating install button for touch devices only */
       /* ---- Onboarding screens (install prompt + asset upload) ---- */
+      /* Onboarding screens. All sizing uses fluid units (clamp/min tied to
+         viewport height) so the card scales down on short/landscape screens
+         and never needs a breakpoint. */
       .onboard {
         position: fixed;
         inset: 0;
@@ -443,37 +446,42 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 22px;
-        padding: 24px;
+        padding: clamp(12px, 3vmin, 24px);
         background: radial-gradient(circle at 50% 30%, #1a2230 0%, #0a0d12 70%);
         color: #fff;
         text-align: center;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
       }
       .onboard.visible { display: flex; }
       .onboard .onboard-card {
         width: 100%;
         max-width: 440px;
+        /* Never taller than the viewport; content shrinks via clamp() so this
+           is rarely hit, but it guarantees no clipping. */
+        max-height: calc(100dvh - clamp(24px, 6vmin, 48px));
+        overflow-y: auto;
         background: rgba(255,255,255,0.04);
         border: 1px solid rgba(255,255,255,0.1);
-        border-radius: 16px;
-        padding: 28px 26px;
+        border-radius: clamp(12px, 2vmin, 16px);
+        padding: clamp(16px, 4vmin, 28px) clamp(16px, 3.5vmin, 26px);
         box-shadow: 0 12px 40px rgba(0,0,0,0.5);
       }
-      .onboard .onboard-emoji { font-size: 44px; line-height: 1; }
+      .onboard .onboard-emoji { font-size: clamp(30px, 7vmin, 44px); line-height: 1; }
       .onboard h2 {
-        margin: 14px 0 6px;
-        font-size: 1.5em;
+        margin: clamp(8px, 2vmin, 14px) 0 6px;
+        font-size: clamp(1.2em, 4vmin, 1.5em);
         color: #fff;
       }
       .onboard .onboard-badge {
         display: inline-block;
-        font-size: 11px;
+        font-size: clamp(10px, 2.4vmin, 11px);
         font-weight: 700;
         letter-spacing: 0.5px;
         text-transform: uppercase;
         padding: 3px 10px;
         border-radius: 999px;
-        margin-bottom: 12px;
+        margin-bottom: clamp(6px, 1.6vmin, 12px);
       }
       .onboard .onboard-badge.recommended {
         background: rgba(82, 196, 26, 0.18); color: #7ee06a;
@@ -484,24 +492,24 @@
         border: 1px solid rgba(255,255,255,0.2);
       }
       .onboard p {
-        margin: 8px 0;
-        font-size: 0.98em;
-        line-height: 1.55;
+        margin: clamp(5px, 1.4vmin, 8px) 0;
+        font-size: clamp(0.9em, 2.6vmin, 0.98em);
+        line-height: 1.5;
         color: #cdd3db;
       }
       .onboard .onboard-actions {
         display: flex;
         flex-direction: column;
-        gap: 10px;
-        margin-top: 22px;
+        gap: clamp(8px, 1.6vmin, 10px);
+        margin-top: clamp(14px, 3vmin, 22px);
       }
       .onboard .btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: 8px;
-        padding: 13px 20px;
-        font-size: 1em;
+        padding: clamp(10px, 2.4vmin, 13px) 20px;
+        font-size: clamp(0.92em, 2.6vmin, 1em);
         font-weight: 600;
         border: none;
         border-radius: 10px;
@@ -517,8 +525,8 @@
       }
       .onboard .btn-ghost:hover { background: rgba(255,255,255,0.06); color: #fff; }
       .onboard .onboard-legal {
-        margin-top: 20px;
-        font-size: 11px;
+        margin-top: clamp(12px, 2.4vmin, 20px);
+        font-size: clamp(10px, 2.2vmin, 11px);
         color: #6b7280;
         line-height: 1.5;
         max-width: 420px;
@@ -527,11 +535,13 @@
       /* Custom file picker for the upload screen */
       .file-drop {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
+        flex-wrap: wrap;
         align-items: center;
-        gap: 8px;
+        justify-content: center;
+        gap: clamp(8px, 2vmin, 14px);
         width: 100%;
-        padding: 22px 16px;
+        padding: clamp(14px, 3vmin, 20px) clamp(16px, 3vmin, 22px);
         margin: 4px 0 6px;
         border: 2px dashed rgba(226,59,46,0.5);
         border-radius: 12px;
@@ -542,13 +552,17 @@
       }
       .file-drop:hover { border-color: rgba(226,59,46,0.9); background: rgba(226,59,46,0.14); }
       .file-drop.has-file { border-style: solid; border-color: #52c41a; background: rgba(82,196,26,0.1); }
-      .file-drop .file-drop-icon { font-size: 30px; }
-      .file-drop .file-drop-label { font-size: 0.95em; }
-      .file-drop .file-drop-name { font-size: 0.82em; color: #7ee06a; word-break: break-all; }
+      .file-drop .file-drop-icon {
+        font-size: clamp(15px, 3vmin, 18px); line-height: 1; flex: 0 0 auto;
+        width: clamp(30px, 6vmin, 38px); height: clamp(30px, 6vmin, 38px);
+        display: flex; align-items: center; justify-content: center;
+        border-radius: 50%; background: rgba(226,59,46,0.18); color: #ff7a6e;
+      }
+      .file-drop .file-drop-label { font-size: clamp(0.88em, 2.4vmin, 0.95em); }
+      .file-drop .file-drop-name { flex: 1 1 100%; text-align: center; font-size: clamp(0.78em, 2vmin, 0.82em); color: #7ee06a; word-break: break-all; }
       .file-drop input[type="file"] {
         position: absolute; width: 1px; height: 1px; opacity: 0; overflow: hidden;
       }
-
     </style>
   </head>
   <body>
@@ -584,7 +598,7 @@
 
         <div id="uploadArea">
           <label class="file-drop" id="fileDrop" for="clawRezFile">
-            <span class="file-drop-icon">📁</span>
+            <span class="file-drop-icon">↑</span>
             <span class="file-drop-label">Choose or drop your CLAW.REZ file</span>
             <span class="file-drop-name" id="fileDropName"></span>
             <input type="file" id="clawRezFile" accept=".REZ,.rez" onchange="validateClawRezFile()" />

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1331,6 +1331,11 @@
         var ua = navigator.userAgent;
         var isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
         var isAndroid = /Android/.test(ua);
+        // Samsung Internet mints WebAPKs with an old targetSdkVersion, so
+        // Android flags installs from it as "unsafe / built for an older
+        // Android version". Chrome's WebAPK does not trip this, so we steer
+        // Samsung users to Chrome. Not fixable site-side (see PWA notes).
+        var isSamsungBrowser = /SamsungBrowser/.test(ua);
         var isSafari =
           /Safari/.test(ua) && !/Chrome|Chromium|Edg|CriOS|FxiOS|OPR/.test(ua);
         var isIOSSafari = isIOS && isSafari;
@@ -1343,6 +1348,14 @@
             return {
               level: 'recommended',
               reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch OpenClaw straight from your home screen.'
+            };
+          }
+          if (isSamsungBrowser) {
+            return {
+              level: 'recommended',
+              reason: 'For the best install on Android, open this page in Chrome. '
+                + 'Samsung Internet can install it too, but Android may warn '
+                + 'that the app is unsafe — that warning does not appear with Chrome.'
             };
           }
           if (isAndroid) {
@@ -1417,6 +1430,7 @@
             isIOSSafari: isIOSSafari,
             isMacSafari: isMacSafari,
             isAndroid: isAndroid,
+            isSamsungBrowser: isSamsungBrowser,
             isMobile: isIOS || isAndroid
           },
           recommendation: recommendation(),

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -20,6 +20,13 @@
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <link rel="manifest" href="site.webmanifest" />
 
+    <!-- iOS PWA: standalone fullscreen mode, hides Safari chrome when added to Home Screen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="OpenClaw" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="theme-color" content="#000000" />
+
     <!-- Viewport adapts to device width, allowing responsive scaling -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
@@ -484,6 +491,39 @@
       #startOverlay:hover svg {
         opacity: 1;
       }
+
+      /* PWA install banner — shown on mobile when game is not running as installed PWA */
+      #pwa-install-banner {
+        display: none;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 9999;
+        background: rgba(0, 0, 0, 0.92);
+        color: #fff;
+        padding: 12px 16px;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+        border-top: 1px solid rgba(255,255,255,0.15);
+      }
+      #pwa-install-banner.visible { display: flex; }
+      #pwa-install-banner .pwa-icon { font-size: 28px; flex-shrink: 0; }
+      #pwa-install-banner .pwa-text { flex: 1; line-height: 1.4; }
+      #pwa-install-banner .pwa-text strong { display: block; }
+      #pwa-install-banner .pwa-text small { color: #aaa; }
+      #pwa-install-banner .pwa-actions { display: flex; gap: 8px; flex-shrink: 0; }
+      #pwa-install-banner button {
+        border: none; border-radius: 6px; padding: 8px 14px;
+        font-size: 13px; cursor: pointer; font-weight: 600;
+      }
+      #pwa-install-banner .btn-install {
+        background: var(--primary-color); color: #fff;
+      }
+      #pwa-install-banner .btn-dismiss {
+        background: rgba(255,255,255,0.12); color: #ccc;
+      }
     </style>
   </head>
   <body>
@@ -578,6 +618,18 @@
             </button>
           </div>
         </div>
+      </div>
+    </div>
+    <!-- PWA install banner — shown to mobile users not yet running in standalone mode -->
+    <div id="pwa-install-banner" role="banner" aria-label="Install OpenClaw">
+      <span class="pwa-icon">🎮</span>
+      <div class="pwa-text">
+        <strong>Add OpenClaw to your Home Screen</strong>
+        <small>Play fullscreen, no browser chrome</small>
+      </div>
+      <div class="pwa-actions">
+        <button class="btn-install" id="pwa-install-btn">Install</button>
+        <button class="btn-dismiss" id="pwa-dismiss-btn">Later</button>
       </div>
     </div>
     <div class="debug_panel" style="display: none">
@@ -1153,6 +1205,89 @@
       if (!checkBrowserSupport()) {
         document.getElementById('loading').textContent = 'Browser not supported';
         throw new Error('Browser not supported');
+      }
+    </script>
+    <!-- PWA install prompt logic -->
+    <script>
+      (function () {
+        var banner = document.getElementById('pwa-install-banner');
+        var installBtn = document.getElementById('pwa-install-btn');
+        var dismissBtn = document.getElementById('pwa-dismiss-btn');
+        var deferredPrompt = null;
+        var DISMISS_KEY = 'pwa_install_dismissed';
+
+        // Don't show if already running as PWA or user dismissed
+        var isStandalone =
+          window.matchMedia('(display-mode: fullscreen)').matches ||
+          window.matchMedia('(display-mode: standalone)').matches ||
+          window.navigator.standalone === true;
+
+        if (isStandalone || localStorage.getItem(DISMISS_KEY)) return;
+
+        // Android Chrome: capture the native install prompt
+        window.addEventListener('beforeinstallprompt', function (e) {
+          e.preventDefault();
+          deferredPrompt = e;
+          // Only show on mobile
+          if (window.innerWidth <= 1024) {
+            banner.classList.add('visible');
+          }
+        });
+
+        // iOS: show manual instructions (no beforeinstallprompt support)
+        var isIOS =
+          /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+        var isIOSSafari =
+          isIOS && /Safari/.test(navigator.userAgent) && !/CriOS|FxiOS/.test(navigator.userAgent);
+        if (isIOSSafari && !isStandalone) {
+          // Show banner with iOS-specific text
+          var textEl = banner.querySelector('.pwa-text small');
+          if (textEl) {
+            textEl.textContent = 'Tap Share ↓ then “Add to Home Screen”';
+          }
+          installBtn.textContent = 'How?';
+          installBtn.addEventListener('click', function () {
+            alert(
+              'To install OpenClaw on iOS:
+
+' +
+              '1. Tap the Share button (↑) in Safari
+' +
+              '2. Scroll down and tap “Add to Home Screen”
+' +
+              '3. Tap “Add” — the game will open fullscreen!'
+            );
+          });
+          banner.classList.add('visible');
+        }
+
+        installBtn.addEventListener('click', function () {
+          if (!deferredPrompt) return;
+          deferredPrompt.prompt();
+          deferredPrompt.userChoice.then(function (result) {
+            deferredPrompt = null;
+            banner.classList.remove('visible');
+            if (result.outcome === 'accepted') {
+              localStorage.setItem(DISMISS_KEY, '1');
+            }
+          });
+        });
+
+        dismissBtn.addEventListener('click', function () {
+          banner.classList.remove('visible');
+          localStorage.setItem(DISMISS_KEY, '1');
+        });
+      })();
+    </script>
+
+    <!-- Service Worker: enables PWA installability and offline shell caching -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('./sw.js').catch(function (err) {
+            console.warn('[SW] Registration failed:', err);
+          });
+        });
       }
     </script>
   </body>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1216,21 +1216,52 @@
         var deferredPrompt = null;
         var DISMISS_KEY = 'pwa_install_dismissed';
 
+        console.log('[PWA] Install prompt script running');
+
         // Don't show if already running as PWA or user dismissed
         var isStandalone =
           window.matchMedia('(display-mode: fullscreen)').matches ||
           window.matchMedia('(display-mode: standalone)').matches ||
           window.navigator.standalone === true;
 
-        if (isStandalone || localStorage.getItem(DISMISS_KEY)) return;
+        console.log('[PWA] isStandalone:', isStandalone, '| dismissed:', !!localStorage.getItem(DISMISS_KEY));
 
-        // Android Chrome: capture the native install prompt
+        if (isStandalone) {
+          console.log('[PWA] Already running as installed app — banner suppressed');
+          return;
+        }
+        if (localStorage.getItem(DISMISS_KEY)) {
+          console.log('[PWA] Previously dismissed. Run localStorage.removeItem("pwa_install_dismissed") then reload to re-enable.');
+          return;
+        }
+
+        // Android/Desktop Chrome: capture the native install prompt
         window.addEventListener('beforeinstallprompt', function (e) {
           e.preventDefault();
           deferredPrompt = e;
-          // Show install banner on all platforms (desktop Chrome, mobile, etc.)
           banner.classList.add('visible');
+          console.log('[PWA] beforeinstallprompt fired — banner shown');
         });
+
+        // Confirm successful installation
+        window.addEventListener('appinstalled', function () {
+          console.log('[PWA] App installed successfully');
+          banner.classList.remove('visible');
+          localStorage.setItem(DISMISS_KEY, '1');
+        });
+
+        // Diagnostic: if the prompt never fires, tell the user why it might be
+        setTimeout(function () {
+          if (!deferredPrompt && !isStandalone) {
+            console.log(
+              '[PWA] beforeinstallprompt has not fired after 3s. Possible reasons:\n' +
+              '  - App is already installed (check chrome://apps)\n' +
+              '  - Chrome engagement heuristic not yet met (interact with the page)\n' +
+              '  - Manifest or service worker not valid (check Application tab)\n' +
+              '  - Prompt already dismissed this session'
+            );
+          }
+        }, 3000);
 
         // iOS: show manual instructions (no beforeinstallprompt support)
         var isIOS =
@@ -1246,13 +1277,9 @@
           installBtn.textContent = 'How?';
           installBtn.addEventListener('click', function () {
             alert(
-              'To install OpenClaw on iOS:
-
-' +
-              '1. Tap the Share button (↑) at the bottom
-' +
-              '2. Scroll down and tap “Add to Home Screen”
-' +
+              'To install OpenClaw on iOS:\n\n' +
+              '1. Tap the Share button (↑) at the bottom\n' +
+              '2. Scroll down and tap “Add to Home Screen”\n' +
               '3. Tap “Add” — the game will launch fullscreen!'
             );
           });

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1228,10 +1228,8 @@
         window.addEventListener('beforeinstallprompt', function (e) {
           e.preventDefault();
           deferredPrompt = e;
-          // Only show on mobile
-          if (window.innerWidth <= 1024) {
-            banner.classList.add('visible');
-          }
+          // Show install banner on all platforms (desktop Chrome, mobile, etc.)
+          banner.classList.add('visible');
         });
 
         // iOS: show manual instructions (no beforeinstallprompt support)

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1251,11 +1251,11 @@
               'To install OpenClaw on iOS:
 
 ' +
-              '1. Tap the Share button (↑) in Safari
+              '1. Tap the Share button (↑) at the bottom
 ' +
               '2. Scroll down and tap “Add to Home Screen”
 ' +
-              '3. Tap “Add” — the game will open fullscreen!'
+              '3. Tap “Add” — the game will launch fullscreen!'
             );
           });
           banner.classList.add('visible');
@@ -1284,9 +1284,18 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function () {
-          navigator.serviceWorker.register('./sw.js').catch(function (err) {
-            console.warn('[SW] Registration failed:', err);
-          });
+          navigator.serviceWorker
+            .register('./sw.js', { scope: './' })
+            .then(function (reg) {
+              console.log('[SW] Registered successfully', reg.scope);
+              // Check for updates periodically (once per day)
+              setInterval(function () {
+                reg.update();
+              }, 24 * 60 * 60 * 1000);
+            })
+            .catch(function (err) {
+              console.warn('[SW] Registration failed:', err);
+            });
         });
       }
     </script>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -492,30 +492,35 @@
         opacity: 1;
       }
 
-      /* PWA install banner — shown on mobile when game is not running as installed PWA */
+      /* PWA install prompt — compact card, bottom-right on wide screens.
+         Sits above #startOverlay (z-index 10000); a capture-phase JS guard also
+         stops clicks from reaching the overlay / game input listeners. */
       #pwa-install-banner {
         display: none;
         position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: 9999;
+        bottom: 16px;
+        right: 16px;
+        left: auto;
+        z-index: 10001;
+        max-width: min(560px, calc(100vw - 32px));
         background: rgba(0, 0, 0, 0.92);
         color: #fff;
-        padding: 12px 16px;
+        padding: 12px 14px;
         align-items: center;
-        gap: 12px;
+        gap: 10px;
         font-size: 14px;
-        border-top: 1px solid rgba(255,255,255,0.15);
+        border: 1px solid rgba(255,255,255,0.15);
+        border-radius: 12px;
+        box-shadow: 0 6px 24px rgba(0,0,0,0.45);
       }
       #pwa-install-banner.visible { display: flex; }
-      #pwa-install-banner .pwa-icon { font-size: 28px; flex-shrink: 0; }
-      #pwa-install-banner .pwa-text { flex: 1; line-height: 1.4; }
-      #pwa-install-banner .pwa-text strong { display: block; }
-      #pwa-install-banner .pwa-text small { color: #aaa; }
-      #pwa-install-banner .pwa-actions { display: flex; gap: 8px; flex-shrink: 0; }
+      #pwa-install-banner .pwa-icon { font-size: 24px; flex-shrink: 0; }
+      #pwa-install-banner .pwa-text { flex: 1; line-height: 1.35; min-width: 0; white-space: nowrap; }
+      #pwa-install-banner .pwa-text strong { display: block; font-size: 13px; }
+      #pwa-install-banner .pwa-text small { color: #aaa; font-size: 12px; }
+      #pwa-install-banner .pwa-actions { display: flex; gap: 6px; flex-shrink: 0; }
       #pwa-install-banner button {
-        border: none; border-radius: 6px; padding: 8px 14px;
+        border: none; border-radius: 6px; padding: 7px 12px;
         font-size: 13px; cursor: pointer; font-weight: 600;
       }
       #pwa-install-banner .btn-install {
@@ -523,6 +528,15 @@
       }
       #pwa-install-banner .btn-dismiss {
         background: rgba(255,255,255,0.12); color: #ccc;
+      }
+      /* Narrow screens: stretch to a bottom bar so the card never overflows */
+      @media (max-width: 480px) {
+        #pwa-install-banner {
+          left: 12px;
+          right: 12px;
+          bottom: 12px;
+          max-width: none;
+        }
       }
     </style>
   </head>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1483,22 +1483,68 @@
       })();
     </script>
 
-    <!-- Service Worker: enables PWA installability and offline shell caching -->
+    <!-- Service Worker: installability + offline shell, with self-heal safety
+         net so a bad deploy can never permanently strand a client (important
+         on mobile, where clearing a stuck SW by hand is painful). -->
     <script>
       if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function () {
-          navigator.serviceWorker
-            .register('./sw.js', { scope: './' })
-            .then(function (reg) {
-              // Check for updates periodically (once per day)
-              setInterval(function () {
-                reg.update();
-              }, 24 * 60 * 60 * 1000);
-            })
-            .catch(function (err) {
-              console.warn('[SW] Registration failed:', err);
+        (function () {
+          // --- Remote kill-switch -------------------------------------------
+          // sw-control.json carries an "unregister" id. When that id changes,
+          // every client unregisters its SW + clears caches exactly once (we
+          // remember the last-handled id), then reloads clean. Page-side on
+          // purpose: it works even if the installed SW is broken. Fetched
+          // network-fresh (no-store) and bypassed by the SW.
+          function checkKillSwitch() {
+            return fetch('./sw-control.json', { cache: 'no-store' })
+              .then(function (r) { return r.ok ? r.json() : null; })
+              .then(function (ctl) {
+                if (!ctl) return false;
+                var id = String(ctl.unregister || '');
+                if (!id) return false;
+                var seen = localStorage.getItem('sw_unregister_id');
+                if (id === seen) return false; // already handled this signal
+                localStorage.setItem('sw_unregister_id', id);
+                console.warn('[SW] Kill-switch tripped (' + id + ') — clearing.');
+                return navigator.serviceWorker.getRegistrations()
+                  .then(function (regs) {
+                    return Promise.all(regs.map(function (r) { return r.unregister(); }));
+                  })
+                  .then(function () {
+                    return (self.caches ? caches.keys() : Promise.resolve([]));
+                  })
+                  .then(function (keys) {
+                    return Promise.all(keys.map(function (k) { return caches.delete(k); }));
+                  })
+                  .then(function () { location.reload(); return true; });
+              })
+              .catch(function () { return false; });
+          }
+
+          // --- Auto-reload when a new SW takes control ----------------------
+          // Guarded so it fires at most once (no reload loop).
+          var refreshing = false;
+          navigator.serviceWorker.addEventListener('controllerchange', function () {
+            if (refreshing) return;
+            refreshing = true;
+            location.reload();
+          });
+
+          window.addEventListener('load', function () {
+            checkKillSwitch().then(function (tripped) {
+              if (tripped) return; // reloading; skip registration this pass
+              navigator.serviceWorker
+                .register('./sw.js', { scope: './' })
+                .then(function (reg) {
+                  // Periodic update check (once per day) + on focus.
+                  setInterval(function () { reg.update(); }, 24 * 60 * 60 * 1000);
+                })
+                .catch(function (err) {
+                  console.warn('[SW] Registration failed:', err);
+                });
             });
-        });
+          });
+        })();
       }
     </script>
   </body>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1227,95 +1227,93 @@
         var banner = document.getElementById('pwa-install-banner');
         var installBtn = document.getElementById('pwa-install-btn');
         var dismissBtn = document.getElementById('pwa-dismiss-btn');
+        var textEl = banner.querySelector('.pwa-text small');
         var deferredPrompt = null;
         var DISMISS_KEY = 'pwa_install_dismissed';
 
-        console.log('[PWA] Install prompt script running');
-
-        // Don't show if already running as PWA or user dismissed
+        // Detect an already-installed PWA. Note: display-mode: fullscreen is
+        // deliberately NOT checked — it also matches the Fullscreen API, which
+        // this game uses, and would suppress the banner during normal play.
         var isStandalone =
-          window.matchMedia('(display-mode: fullscreen)').matches ||
           window.matchMedia('(display-mode: standalone)').matches ||
           window.navigator.standalone === true;
 
-        console.log('[PWA] isStandalone:', isStandalone, '| dismissed:', !!localStorage.getItem(DISMISS_KEY));
+        if (isStandalone || localStorage.getItem(DISMISS_KEY)) return;
 
-        if (isStandalone) {
-          console.log('[PWA] Already running as installed app — banner suppressed');
-          return;
-        }
-        if (localStorage.getItem(DISMISS_KEY)) {
-          console.log('[PWA] Previously dismissed. Run localStorage.removeItem("pwa_install_dismissed") then reload to re-enable.');
-          return;
+        var ua = navigator.userAgent;
+        var isIOS = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
+        // Safari = has Safari token but is not Chrome/Chromium/Edge/Firefox-iOS.
+        var isSafari =
+          /Safari/.test(ua) && !/Chrome|Chromium|Edg|CriOS|FxiOS|OPR/.test(ua);
+        var isIOSSafari = isIOS && isSafari;
+        var isMacSafari = isSafari && /Macintosh/.test(ua) && !isIOS;
+
+        function dismiss() {
+          banner.classList.remove('visible');
+          localStorage.setItem(DISMISS_KEY, '1');
         }
 
-        // Android/Desktop Chrome: capture the native install prompt
+        // The only programmatic install API. Chrome/Edge/Chromium-with-Google
+        // fire this; Safari and Firefox never do. When present, the Install
+        // button triggers the real one-click prompt; the banner is shown here
+        // (rather than up-front) so it only appears once install is possible.
         window.addEventListener('beforeinstallprompt', function (e) {
           e.preventDefault();
           deferredPrompt = e;
           banner.classList.add('visible');
-          console.log('[PWA] beforeinstallprompt fired — banner shown');
         });
 
-        // Confirm successful installation
-        window.addEventListener('appinstalled', function () {
-          console.log('[PWA] App installed successfully');
-          banner.classList.remove('visible');
-          localStorage.setItem(DISMISS_KEY, '1');
-        });
-
-        // Diagnostic: if the prompt never fires, tell the user why it might be
-        setTimeout(function () {
-          if (!deferredPrompt && !isStandalone) {
-            console.log(
-              '[PWA] beforeinstallprompt has not fired after 3s. Possible reasons:\n' +
-              '  - App is already installed (check chrome://apps)\n' +
-              '  - Chrome engagement heuristic not yet met (interact with the page)\n' +
-              '  - Manifest or service worker not valid (check Application tab)\n' +
-              '  - Prompt already dismissed this session'
-            );
-          }
-        }, 3000);
-
-        // iOS: show manual instructions (no beforeinstallprompt support)
-        var isIOS =
-          /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-        var isIOSSafari =
-          isIOS && /Safari/.test(navigator.userAgent) && !/CriOS|FxiOS/.test(navigator.userAgent);
-        if (isIOSSafari && !isStandalone) {
-          // Show banner with iOS-specific text
-          var textEl = banner.querySelector('.pwa-text small');
-          if (textEl) {
-            textEl.textContent = 'Tap Share ↓ then “Add to Home Screen”';
-          }
-          installBtn.textContent = 'How?';
-          installBtn.addEventListener('click', function () {
-            alert(
-              'To install OpenClaw on iOS:\n\n' +
-              '1. Tap the Share button (↑) at the bottom\n' +
-              '2. Scroll down and tap “Add to Home Screen”\n' +
-              '3. Tap “Add” — the game will launch fullscreen!'
-            );
-          });
-          banner.classList.add('visible');
-        }
+        window.addEventListener('appinstalled', dismiss);
 
         installBtn.addEventListener('click', function () {
-          if (!deferredPrompt) return;
-          deferredPrompt.prompt();
-          deferredPrompt.userChoice.then(function (result) {
-            deferredPrompt = null;
-            banner.classList.remove('visible');
-            if (result.outcome === 'accepted') {
-              localStorage.setItem(DISMISS_KEY, '1');
-            }
-          });
+          if (deferredPrompt) {
+            deferredPrompt.prompt();
+            deferredPrompt.userChoice.then(function (result) {
+              deferredPrompt = null;
+              banner.classList.remove('visible');
+              if (result.outcome === 'accepted') {
+                localStorage.setItem(DISMISS_KEY, '1');
+              }
+            });
+          } else if (isIOSSafari) {
+            alert(
+              'Install OpenClaw on iOS:\n\n' +
+              '1. Tap the Share button at the bottom of Safari\n' +
+              '2. Choose “Add to Home Screen”\n' +
+              '3. Tap “Add” — the game launches fullscreen.'
+            );
+          } else if (isMacSafari) {
+            alert(
+              'Install OpenClaw on Mac:\n\n' +
+              '1. Open the File menu in Safari\n' +
+              '2. Choose “Add to Dock…”\n' +
+              '3. Confirm — the game opens in its own window.'
+            );
+          }
         });
 
-        dismissBtn.addEventListener('click', function () {
-          banner.classList.remove('visible');
-          localStorage.setItem(DISMISS_KEY, '1');
-        });
+        dismissBtn.addEventListener('click', dismiss);
+
+        // Belt-and-suspenders: the start overlay and the game attach input
+        // listeners high in the tree. Stop every pointer/click/touch event that
+        // originates inside the banner from bubbling up to them, so interacting
+        // with the banner never also starts the game.
+        ['click', 'pointerdown', 'pointerup', 'mousedown', 'mouseup', 'touchstart', 'touchend'].forEach(
+          function (type) {
+            banner.addEventListener(type, function (e) { e.stopPropagation(); }, true);
+          }
+        );
+
+        // Safari has no install event, so show the banner up-front there with
+        // platform-specific copy. Other browsers without the event (Firefox,
+        // plain Chromium) have no reliable install path, so no banner is shown.
+        if (isIOSSafari && textEl) {
+          textEl.textContent = 'Tap Share, then “Add to Home Screen”';
+          banner.classList.add('visible');
+        } else if (isMacSafari && textEl) {
+          textEl.textContent = 'File menu → “Add to Dock”';
+          banner.classList.add('visible');
+        }
       })();
     </script>
 
@@ -1326,7 +1324,6 @@
           navigator.serviceWorker
             .register('./sw.js', { scope: './' })
             .then(function (reg) {
-              console.log('[SW] Registered successfully', reg.scope);
               // Check for updates periodically (once per day)
               setInterval(function () {
                 reg.update();

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -336,7 +336,7 @@
       #assetUpload p { text-align: left; }
 
       #uploadArea {
-        margin-top: 18px;
+        margin-top: 8px;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -569,6 +569,7 @@
       }
       .file-drop .file-drop-label { font-size: clamp(0.88em, 2.4vmin, 0.95em); }
       .file-drop .file-drop-name { flex: 1 1 100%; text-align: center; font-size: clamp(0.78em, 2vmin, 0.82em); color: #7ee06a; word-break: break-all; }
+      .file-drop .file-drop-name:empty { display: none; }
       .file-drop input[type="file"] {
         position: absolute; width: 1px; height: 1px; opacity: 0; overflow: hidden;
       }
@@ -607,7 +608,7 @@
 
         <div id="uploadArea">
           <label class="file-drop" id="fileDrop" for="clawRezFile">
-            <span class="file-drop-icon">↑</span>
+            <span class="file-drop-icon"><svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V9"/><path d="m7 14 5-5 5 5"/><path d="M5 3h14"/></svg></span>
             <span class="file-drop-label">Choose or drop your CLAW.REZ file</span>
             <span class="file-drop-name" id="fileDropName"></span>
             <input type="file" id="clawRezFile" accept=".REZ,.rez" onchange="validateClawRezFile()" />
@@ -672,7 +673,7 @@
               aria-label="Install OpenClaw"
               style="display: none"
             >
-              ⬇
+              <svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
             </button>
             <button
               class="control-btn"
@@ -694,7 +695,7 @@
         <h2>Install OpenClaw?</h2>
         <p id="installReason">Install OpenClaw for the best experience.</p>
         <div class="onboard-actions">
-          <button class="btn btn-primary" id="installYesBtn">⬇ Install OpenClaw</button>
+          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install OpenClaw</button>
           <button class="btn btn-ghost" id="installSkipBtn">Not now</button>
         </div>
       </div>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1468,6 +1468,26 @@
           if (watchdog) { clearTimeout(watchdog); watchdog = null; }
         };
 
+        // Catch fatal WASM boot failures that are thrown rather than routed
+        // through Module.onAbort — e.g. a corrupt/empty CLAW.REZ makes the
+        // runtime throw "ASM_CONSTS[...] is not a function" or a "null
+        // function" RuntimeError. We only treat these as load failures BEFORE
+        // the game has reported running, and only when the message matches the
+        // Emscripten/WASM boot-failure signatures, so we never hijack benign
+        // runtime errors (e.g. Vite's HMR websocket) or post-boot glitches.
+        var BOOT_FAIL = /ASM_CONSTS|null function|RuntimeError|abort\(|table index is out of bounds|memory access out of bounds/i;
+        function maybeBootFailure(msg) {
+          if (window.__openClawRunning || shown) return;
+          if (msg && BOOT_FAIL.test(String(msg))) window.showLoadError();
+        }
+        window.addEventListener('error', function (e) {
+          maybeBootFailure((e && e.message) || (e && e.error && e.error.message));
+        });
+        window.addEventListener('unhandledrejection', function (e) {
+          var r = e && e.reason;
+          maybeBootFailure(r && (r.message || r));
+        });
+
         var clearBtn = document.getElementById('loadErrorClearBtn');
         var reloadBtn = document.getElementById('loadErrorReloadBtn');
         if (clearBtn) clearBtn.addEventListener('click', function () {

--- a/Build_Release/site.webmanifest
+++ b/Build_Release/site.webmanifest
@@ -1,1 +1,40 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "OpenClaw",
+  "short_name": "OpenClaw",
+  "description": "Captain Claw (1997) platformer reimplementation",
+  "start_url": "./openclaw.html",
+  "display": "fullscreen",
+  "orientation": "landscape",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ],
+  "categories": ["games"],
+  "lang": "en"
+}

--- a/Build_Release/site.webmanifest
+++ b/Build_Release/site.webmanifest
@@ -35,6 +35,23 @@
       "type": "image/png"
     }
   ],
-  "categories": ["games"],
-  "lang": "en"
+  "categories": [
+    "games"
+  ],
+  "lang": "en",
+  "scope": "./",
+  "screenshots": [
+    {
+      "src": "android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "form_factor": "narrow"
+    },
+    {
+      "src": "android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "form_factor": "wide"
+    }
+  ]
 }

--- a/Build_Release/sw-control.json
+++ b/Build_Release/sw-control.json
@@ -1,0 +1,3 @@
+{
+  "unregister": ""
+}

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -1,6 +1,6 @@
 // PWA shell cache — includes all app bootstrap assets
 // Vite will serve these with consistent, deterministic paths
-const CACHE_NAME = "openclaw-v1";
+const CACHE_NAME = "openclaw-v2";
 
 // Essential assets needed to boot the game
 // These are served by Vite and have stable, hashed filenames in production
@@ -63,42 +63,43 @@ self.addEventListener("activate", (event) => {
   );
 });
 
-// Fetch strategy: cache-first for shell, network-first for game data
+// Fetch strategy: cache-first for the small shell, hands-off for everything
+// else. Anything the SW does not explicitly handle is left to the browser by
+// NOT calling event.respondWith — critical for large/streamed assets.
 self.addEventListener("fetch", (event) => {
-  const url = new URL(event.request.url);
-  const pathname = url.pathname;
+  const req = event.request;
+  const url = new URL(req.url);
 
-  // Never cache large WASM/binary assets — they have their own IndexedDB caching
-  const BYPASS_CACHE = [".wasm", ".data", "ASSETS.ZIP"];
-  if (BYPASS_CACHE.some((ext) => pathname.endsWith(ext))) {
-    event.respondWith(fetch(event.request));
-    return;
+  // Only ever touch same-origin GET requests.
+  if (req.method !== "GET" || url.origin !== self.location.origin) return;
+
+  // Never intercept range requests (WASM/data/media stream with these; a SW
+  // returning a 200 for a Range request breaks playback and wasm streaming).
+  if (req.headers.has("range")) return;
+
+  // Large binaries are loaded/streamed directly and have their own IndexedDB
+  // cache — the SW must not touch them at all (letting a failed inner fetch
+  // surface as a FetchEvent error would abort the game load).
+  const HANDS_OFF = [".wasm", ".data", ".zip", ".mp4"];
+  const path = url.pathname.toLowerCase();
+  if (HANDS_OFF.some((ext) => path.endsWith(ext)) || path.includes("assets.zip")) {
+    return; // browser handles it natively
   }
 
-  // Cache-first: shell assets (JS, HTML, icons, manifest)
-  // Return from cache if available, fall back to network
+  // Cache-first for the shell; fall back to network and cache the result.
+  // If the network fails, return any cached copy rather than throwing.
   event.respondWith(
-    caches.match(event.request).then((cached) => {
+    caches.match(req).then((cached) => {
       if (cached) return cached;
-
-      return fetch(event.request).then((response) => {
-        // Only cache successful responses with valid content-type
-        if (
-          !response ||
-          response.status !== 200 ||
-          response.type === "opaque"
-        ) {
+      return fetch(req)
+        .then((response) => {
+          if (response && response.status === 200 && response.type === "basic") {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(req, clone));
+          }
           return response;
-        }
-
-        // Store a clone in cache for future use
-        const clone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => {
-          cache.put(event.request, clone);
-        });
-
-        return response;
-      });
+        })
+        .catch(() => caches.match(req));
     })
   );
 });

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -1,6 +1,9 @@
+// PWA shell cache — includes all app bootstrap assets
+// Vite will serve these with consistent, deterministic paths
 const CACHE_NAME = "openclaw-v1";
 
-// Shell assets to cache on install (everything needed to boot)
+// Essential assets needed to boot the game
+// These are served by Vite and have stable, hashed filenames in production
 const SHELL_ASSETS = [
   "./openclaw.html",
   "./openclaw.js",
@@ -18,52 +21,82 @@ const SHELL_ASSETS = [
   "./android-chrome-512x512.png",
   "./apple-touch-icon.png",
   "./favicon.ico",
+  "./favicon-16x16.png",
+  "./favicon-32x32.png",
 ];
 
+// On install: cache the app shell
 self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(CACHE_NAME)
-      .then((cache) => cache.addAll(SHELL_ASSETS))
-      .then(() => self.skipWaiting())
+      .then((cache) => {
+        // Use addAll to fail fast if any asset is missing
+        return cache.addAll(SHELL_ASSETS);
+      })
+      .then(() => {
+        // Force waiting service worker to become active immediately
+        return self.skipWaiting();
+      })
   );
 });
 
+// On activate: remove old caches if CACHE_NAME changes
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
       .keys()
       .then((keys) =>
         Promise.all(
-          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
+          keys
+            .filter((k) => k !== CACHE_NAME)
+            .map((k) => {
+              console.log("[SW] Deleting old cache:", k);
+              return caches.delete(k);
+            })
         )
       )
-      .then(() => self.clients.claim())
+      .then(() => {
+        // Claim all clients immediately (no need to reload page)
+        return self.clients.claim();
+      })
   );
 });
 
+// Fetch strategy: cache-first for shell, network-first for game data
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
+  const pathname = url.pathname;
 
-  // Never cache WASM, game data or ASSETS.ZIP — they are large and loaded by the
-  // asset-loader with its own IndexedDB caching strategy.
-  const bypass = [".wasm", ".data", "ASSETS.ZIP"].some((ext) =>
-    url.pathname.endsWith(ext)
-  );
-  if (bypass) {
+  // Never cache large WASM/binary assets — they have their own IndexedDB caching
+  const BYPASS_CACHE = [".wasm", ".data", "ASSETS.ZIP"];
+  if (BYPASS_CACHE.some((ext) => pathname.endsWith(ext))) {
     event.respondWith(fetch(event.request));
     return;
   }
 
-  // Cache-first for everything else (shell + small assets)
+  // Cache-first: shell assets (JS, HTML, icons, manifest)
+  // Return from cache if available, fall back to network
   event.respondWith(
     caches.match(event.request).then((cached) => {
       if (cached) return cached;
+
       return fetch(event.request).then((response) => {
-        if (!response || response.status !== 200 || response.type === "opaque")
+        // Only cache successful responses with valid content-type
+        if (
+          !response ||
+          response.status !== 200 ||
+          response.type === "opaque"
+        ) {
           return response;
+        }
+
+        // Store a clone in cache for future use
         const clone = response.clone();
-        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, clone);
+        });
+
         return response;
       });
     })

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -1,0 +1,71 @@
+const CACHE_NAME = "openclaw-v1";
+
+// Shell assets to cache on install (everything needed to boot)
+const SHELL_ASSETS = [
+  "./openclaw.html",
+  "./openclaw.js",
+  "./game-init.js",
+  "./asset-storage.js",
+  "./asset-loader.js",
+  "./resource-loader.js",
+  "./graphics-bridge.js",
+  "./texture-bridge.js",
+  "./save-storage.js",
+  "./gamepad-bridge.js",
+  "./keyboard-capture.js",
+  "./site.webmanifest",
+  "./android-chrome-192x192.png",
+  "./android-chrome-512x512.png",
+  "./apple-touch-icon.png",
+  "./favicon.ico",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(SHELL_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  // Never cache WASM, game data or ASSETS.ZIP — they are large and loaded by the
+  // asset-loader with its own IndexedDB caching strategy.
+  const bypass = [".wasm", ".data", "ASSETS.ZIP"].some((ext) =>
+    url.pathname.endsWith(ext)
+  );
+  if (bypass) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
+  // Cache-first for everything else (shell + small assets)
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request).then((response) => {
+        if (!response || response.status !== 200 || response.type === "opaque")
+          return response;
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        return response;
+      });
+    })
+  );
+});

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -1,12 +1,11 @@
 // PWA shell cache — includes all app bootstrap assets
 // Vite will serve these with consistent, deterministic paths
-const CACHE_NAME = "openclaw-v2";
+const CACHE_NAME = "openclaw-v3";
 
 // Essential assets needed to boot the game
 // These are served by Vite and have stable, hashed filenames in production
 const SHELL_ASSETS = [
   "./openclaw.html",
-  "./openclaw.js",
   "./game-init.js",
   "./asset-storage.js",
   "./asset-loader.js",

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -129,7 +129,7 @@
       // 320px (phone portrait/landscape) → 1.0x, 820px (tablet portrait) → 1.32x, 1920px+ → 2.0x
       ":root{",
       "  --tc-scale: clamp(1, (100vmin - 320px) / 1600px + 1, 2);",
-      "  --tc-corner-dist: calc(30px * var(--tc-scale));",
+      "  --tc-corner-dist: calc(40px * var(--tc-scale));",
       "}",
       "",
       "#touchControls{position:fixed;inset:0;z-index:9000;pointer-events:none;",
@@ -246,15 +246,29 @@
       "#tcDleft{left:0;top:calc(47px * var(--tc-scale));}",
       "#tcDright{left:calc(94px * var(--tc-scale));top:calc(47px * var(--tc-scale));}",
       // Movement-mode toggle — small button above the movement control, scaled.
-      "#tcMoveToggle{position:absolute;left:var(--tc-corner-dist);bottom:calc(178px * var(--tc-scale));width:calc(48px * var(--tc-scale));height:calc(48px * var(--tc-scale));",
+      "#tcMoveToggle{position:absolute;left:var(--tc-corner-dist);bottom:calc(178px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));",
       "  border-radius:50%;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
-      "    rgba(252,239,82,0.25) 0 10%,rgba(248,232,110,0.25) 10% 20%,",
-      "    rgba(253,253,183,0.25) 20% 30%,rgba(251,244,214,0.25) 30% 40%,",
-      "    rgba(172,120,53,0.25) 40% 50%,rgba(208,170,62,0.25) 50% 60%,",
-      "    rgba(242,204,77,0.25) 60% 70%,rgba(244,219,99,0.25) 70% 80%,",
-      "    rgba(249,237,146,0.25) 80% 90%,rgba(239,216,112,0.25) 90% 100%);",
+      "    rgba(252,239,82,0.16) 0 10%,rgba(248,232,110,0.16) 10% 20%,",
+      "    rgba(253,253,183,0.16) 20% 30%,rgba(251,244,214,0.16) 30% 40%,",
+      "    rgba(172,120,53,0.16) 40% 50%,rgba(208,170,62,0.16) 50% 60%,",
+      "    rgba(242,204,77,0.16) 60% 70%,rgba(244,219,99,0.16) 70% 80%,",
+      "    rgba(249,237,146,0.16) 80% 90%,rgba(239,216,112,0.16) 90% 100%);",
       "  color:#fff;font:bold calc(10px * var(--tc-scale)) sans-serif;",
+      "  text-shadow:calc(-1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(-1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000;",
+      "  display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;}",
+      // Install button — mirrors the movement toggle on the right side, same
+      // gold-band style and bottom distance. Hidden once the app is installed
+      // (JS removes it) or on desktop.
+      "#tcInstall{position:absolute;right:var(--tc-corner-dist);bottom:calc(178px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));",
+      "  border-radius:50%;border:2px solid #000;",
+      "  background:linear-gradient(to bottom,",
+      "    rgba(252,239,82,0.16) 0 10%,rgba(248,232,110,0.16) 10% 20%,",
+      "    rgba(253,253,183,0.16) 20% 30%,rgba(251,244,214,0.16) 30% 40%,",
+      "    rgba(172,120,53,0.16) 40% 50%,rgba(208,170,62,0.16) 50% 60%,",
+      "    rgba(242,204,77,0.16) 60% 70%,rgba(244,219,99,0.16) 70% 80%,",
+      "    rgba(249,237,146,0.16) 80% 90%,rgba(239,216,112,0.16) 90% 100%);",
+      "  color:#fff;font:bold calc(18px * var(--tc-scale)) sans-serif;",
       "  text-shadow:calc(-1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(-1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000;",
       "  display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;}",
       // Show joystick OR d-pad based on the movement mode class on the root.
@@ -264,9 +278,9 @@
       // ---- Portrait placement -------------------------------------------------
       // Adjust button spacing slightly when in portrait orientation
       "@media (orientation: portrait) {",
-      "  #tcJoyBase, #tcDpad{left:calc(15px * var(--tc-scale));bottom:calc(60px * var(--tc-scale));}",
-      "  #tcButtons{right:calc(15px * var(--tc-scale));bottom:calc(60px * var(--tc-scale));}",
-      "  #tcMoveToggle{bottom:calc(208px * var(--tc-scale));}",
+      "  #tcJoyBase, #tcDpad{left:calc(28px * var(--tc-scale));bottom:calc(72px * var(--tc-scale));}",
+      "  #tcButtons{right:calc(28px * var(--tc-scale));bottom:calc(72px * var(--tc-scale));}",
+      "  #tcMoveToggle, #tcInstall{bottom:calc(208px * var(--tc-scale));}",
       "  #tcPause{background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -317,6 +331,7 @@
       '  <div class="tcDbtn" id="tcDright"></div>' +
       "</div>" +
       '<div id="tcMoveToggle">STICK</div>' +
+      '<div id="tcInstall">\u2b07</div>' +
       '<div id="tcButtons">' +
       '  <div class="tcBtn" id="tcJump">JUMP</div>' +
       '  <div class="tcBtn" id="tcAttack">ATK</div>' +
@@ -567,6 +582,26 @@
     });
   }
 
+  // ---- Install button -------------------------------------------------------
+  // Delegates to the shared install API defined in openclaw.html. Removed from
+  // the DOM if the app is already installed or no install path exists.
+  function setupInstallButton(el) {
+    if (!el) return;
+    var api = window.OpenClawInstall;
+    if (!api || api.isInstalled) {
+      el.remove();
+      return;
+    }
+    el.addEventListener("pointerdown", function (e) {
+      markTouchInput(e);
+      vibrate(HAPTIC.light);
+      e.preventDefault();
+      if (typeof api.trigger === "function") api.trigger();
+    });
+    // Hide it for good once the app gets installed mid-session.
+    window.addEventListener("appinstalled", function () { el.remove(); });
+  }
+
   // ---- Init -----------------------------------------------------------------
 
   function init() {
@@ -583,6 +618,7 @@
     setupHoldButton(document.getElementById("tcDleft"), KEY.left, HAPTIC.light);
     setupHoldButton(document.getElementById("tcDright"), KEY.right, HAPTIC.light);
     setupMoveToggle(root, document.getElementById("tcMoveToggle"));
+    setupInstallButton(document.getElementById("tcInstall"));
     // Gameplay buttons
     setupHoldButton(document.getElementById("tcJump"), KEY.jump, HAPTIC.jump);
     setupHoldButton(document.getElementById("tcFire"), KEY.fire, HAPTIC.attack);

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -137,7 +137,7 @@
       "  --tc-corner-dist: calc(40px * var(--tc-scale));",
       "}",
       "",
-      "#touchControls{position:fixed;inset:0;z-index:9000;pointer-events:none;",
+      "#touchControls{position:fixed;z-index:9000;pointer-events:none;","  top:env(safe-area-inset-top,0px);right:env(safe-area-inset-right,0px);","  bottom:env(safe-area-inset-bottom,0px);left:env(safe-area-inset-left,0px);",
       "  display:none;touch-action:none;user-select:none;-webkit-user-select:none;",
       "  -webkit-touch-callout:none;}",
       "#touchControls.visible{display:block;}",

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -336,7 +336,7 @@
       '  <div class="tcDbtn" id="tcDright"></div>' +
       "</div>" +
       '<div id="tcMoveToggle">STICK</div>' +
-      '<div id="tcInstall">\u2b07</div>' +
+      '<div id="tcInstall"><svg class=\"icon-download\" viewBox=\"0 0 24 24\" width=\"1em\" height=\"1em\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><path d=\"M12 3v12\"/><path d=\"m7 10 5 5 5-5\"/><path d=\"M5 21h14\"/></svg></div>' +
       '<div id="tcButtons">' +
       '  <div class="tcBtn" id="tcJump">JUMP</div>' +
       '  <div class="tcBtn" id="tcAttack">ATK</div>' +

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -75,6 +75,11 @@
     Object.keys(heldKeys).forEach(function (code) {
       if (heldKeys[code]) releaseKey(code);
     });
+    // Safety net: clear any stuck visual highlight. A button's pointerup can be
+    // lost when its action triggers a fullscreen/resize transition (the pointer
+    // is retargeted mid-gesture), leaving .active stuck on e.g. the OK button.
+    var stuck = document.querySelectorAll('#touchControls .active');
+    for (var i = 0; i < stuck.length; i++) stuck[i].classList.remove('active');
   }
 
   function getGameState() {
@@ -128,7 +133,7 @@
       // Formula: clamp(min, preferred, max) where preferred scales from 320px to 1920px
       // 320px (phone portrait/landscape) → 1.0x, 820px (tablet portrait) → 1.32x, 1920px+ → 2.0x
       ":root{",
-      "  --tc-scale: clamp(1, (100vmin - 320px) / 1600px + 1, 2);",
+      "  --tc-scale: clamp(0.72, (100vmin - 320px) / 1600px + 0.72, 2);",
       "  --tc-corner-dist: calc(40px * var(--tc-scale));",
       "}",
       "",
@@ -146,7 +151,7 @@
       // FILL alpha kept low (~0.4) for transparency; borders are solid black.
       // Joystick base (bottom-left) — same score-system bands, kept subtler
       // (lower alpha) as it covers more play area.
-      "#tcJoyBase{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(140px * var(--tc-scale));height:calc(140px * var(--tc-scale));",
+      "#tcJoyBase{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(180px * var(--tc-scale));height:calc(180px * var(--tc-scale));",
       "  border-radius:50%;border:2px solid #000;box-shadow:0 0 0 1px rgba(0,0,0,0.5);",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
@@ -155,8 +160,8 @@
       "    rgba(242,204,77,0.4) 60% 70%,rgba(244,219,99,0.4) 70% 80%,",
       "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);",
       "  pointer-events:auto;touch-action:none;}",
-      "#tcJoyThumb{position:absolute;left:50%;top:50%;width:calc(60px * var(--tc-scale));height:calc(60px * var(--tc-scale));",
-      "  margin:calc(-30px * var(--tc-scale)) 0 0 calc(-30px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
+      "#tcJoyThumb{position:absolute;left:50%;top:50%;width:calc(77px * var(--tc-scale));height:calc(77px * var(--tc-scale));",
+      "  margin:calc(-38px * var(--tc-scale)) 0 0 calc(-38px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -164,10 +169,10 @@
       "    rgba(242,204,77,0.4) 60% 70%,rgba(244,219,99,0.4) 70% 80%,",
       "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);}",
       // Action buttons (bottom-right cluster)
-      "#tcButtons{position:absolute;right:calc(24px * var(--tc-scale));bottom:calc(24px * var(--tc-scale));width:calc(180px * var(--tc-scale));height:calc(180px * var(--tc-scale));pointer-events:none;}",
+      "#tcButtons{position:absolute;right:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(200px * var(--tc-scale));height:calc(200px * var(--tc-scale));pointer-events:none;}",
       // 10-band hard-stop gradient sampled from the score display (top->bottom),
       // slightly translucent so gameplay still reads through. Black border.
-      ".tcBtn{position:absolute;width:calc(60px * var(--tc-scale));height:calc(60px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
+      ".tcBtn{position:absolute;width:calc(68px * var(--tc-scale));height:calc(68px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -187,10 +192,10 @@
       "    rgb(249,237,146) 80% 90%,rgb(239,216,112) 90% 100%);}",
       // Diamond layout: 4 buttons at N/E/S/W of the cluster, scaled proportionally.
       // Offsets scale with the button size to maintain spacing ratios.
-      "#tcFire{right:calc(6px * var(--tc-scale));bottom:calc(60px * var(--tc-scale));}",     // E (outer right)
-      "#tcJump{right:calc(60px * var(--tc-scale));bottom:calc(6px * var(--tc-scale));}",     // S (bottom)
-      "#tcWeapon{right:calc(60px * var(--tc-scale));bottom:calc(114px * var(--tc-scale));}", // N (top)
-      "#tcAttack{right:calc(114px * var(--tc-scale));bottom:calc(60px * var(--tc-scale));}", // W (inner left)
+      "#tcFire{right:calc(12px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}",     // E (outer right)
+      "#tcJump{right:calc(66px * var(--tc-scale));bottom:calc(12px * var(--tc-scale));}",     // S (bottom)
+      "#tcWeapon{right:calc(66px * var(--tc-scale));bottom:calc(120px * var(--tc-scale));}", // N (top)
+      "#tcAttack{right:calc(120px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}", // W (inner left)
       // Pause (top-center)
       "#tcPause{position:absolute;left:50%;top:calc(6px * var(--tc-scale));transform:translateX(-50%);",
       "  width:calc(42px * var(--tc-scale));height:calc(30px * var(--tc-scale));border-radius:4px;border:2px solid #000;",
@@ -211,8 +216,8 @@
       "    rgb(249,237,146) 80% 90%,rgb(239,216,112) 90% 100%);}",
       // Menu buttons (Select / Back) — reuse the JUMP / ATK slots so switching
       // modes doesn't shift button positions. Scaled proportionally.
-      "#tcBack{right:calc(6px * var(--tc-scale));bottom:calc(60px * var(--tc-scale));}",     // E (same slot as Fire)
-      "#tcSelect{right:calc(60px * var(--tc-scale));bottom:calc(6px * var(--tc-scale));}",   // S (same slot as Jump)
+      "#tcBack{right:calc(12px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}",     // E (same slot as Fire)
+      "#tcSelect{right:calc(66px * var(--tc-scale));bottom:calc(12px * var(--tc-scale));}",   // S (same slot as Jump)
       // Mode-based visibility: gameplay shows action buttons + pause; menu shows
       // Select/Back only. Movement control (joystick/d-pad) shows in both.
       "#touchControls.mode-gameplay #tcSelect,#touchControls.mode-gameplay #tcBack{display:none;}",
@@ -221,9 +226,9 @@
       "#touchControls.mode-menu #tcPause{display:none;}",
       // D-pad — plus layout, 4 directions only (no diagonals), same footprint
       // as the joystick base. Button size and layout scaled proportionally.
-      "#tcDpad{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(140px * var(--tc-scale));height:calc(140px * var(--tc-scale));",
+      "#tcDpad{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(180px * var(--tc-scale));height:calc(180px * var(--tc-scale));",
       "  pointer-events:none;}",
-      ".tcDbtn{position:absolute;width:calc(46px * var(--tc-scale));height:calc(46px * var(--tc-scale));border-radius:8px;border:2px solid #000;",
+      ".tcDbtn{position:absolute;width:calc(59px * var(--tc-scale));height:calc(59px * var(--tc-scale));border-radius:8px;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -241,33 +246,33 @@
       "    rgb(172,120,53) 40% 50%,rgb(208,170,62) 50% 60%,",
       "    rgb(242,204,77) 60% 70%,rgb(244,219,99) 70% 80%,",
       "    rgb(249,237,146) 80% 90%,rgb(239,216,112) 90% 100%);}",
-      "#tcDup{left:calc(47px * var(--tc-scale));top:0;}",
-      "#tcDdown{left:calc(47px * var(--tc-scale));top:calc(94px * var(--tc-scale));}",
-      "#tcDleft{left:0;top:calc(47px * var(--tc-scale));}",
-      "#tcDright{left:calc(94px * var(--tc-scale));top:calc(47px * var(--tc-scale));}",
+      "#tcDup{left:calc(60px * var(--tc-scale));top:calc(6px * var(--tc-scale));}",
+      "#tcDdown{left:calc(60px * var(--tc-scale));top:calc(115px * var(--tc-scale));}",
+      "#tcDleft{left:calc(6px * var(--tc-scale));top:calc(60px * var(--tc-scale));}",
+      "#tcDright{left:calc(115px * var(--tc-scale));top:calc(60px * var(--tc-scale));}",
       // Movement-mode toggle — small button above the movement control, scaled.
-      "#tcMoveToggle{position:absolute;left:var(--tc-corner-dist);bottom:calc(178px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));",
+      "#tcMoveToggle{position:absolute;left:var(--tc-corner-dist);bottom:calc(var(--tc-corner-dist) + 190px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));opacity:0.85;",
       "  border-radius:50%;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
-      "    rgba(252,239,82,0.16) 0 10%,rgba(248,232,110,0.16) 10% 20%,",
-      "    rgba(253,253,183,0.16) 20% 30%,rgba(251,244,214,0.16) 30% 40%,",
-      "    rgba(172,120,53,0.16) 40% 50%,rgba(208,170,62,0.16) 50% 60%,",
-      "    rgba(242,204,77,0.16) 60% 70%,rgba(244,219,99,0.16) 70% 80%,",
-      "    rgba(249,237,146,0.16) 80% 90%,rgba(239,216,112,0.16) 90% 100%);",
+      "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
+      "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
+      "    rgba(172,120,53,0.4) 40% 50%,rgba(208,170,62,0.4) 50% 60%,",
+      "    rgba(242,204,77,0.4) 60% 70%,rgba(244,219,99,0.4) 70% 80%,",
+      "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);",
       "  color:#fff;font:bold calc(10px * var(--tc-scale)) sans-serif;",
       "  text-shadow:calc(-1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(-1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000;",
       "  display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;}",
       // Install button — mirrors the movement toggle on the right side, same
       // gold-band style and bottom distance. Hidden once the app is installed
       // (JS removes it) or on desktop.
-      "#tcInstall{position:absolute;right:var(--tc-corner-dist);bottom:calc(178px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));",
+      "#tcInstall{position:absolute;right:var(--tc-corner-dist);bottom:calc(var(--tc-corner-dist) + 190px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));opacity:0.85;",
       "  border-radius:50%;border:2px solid #000;",
       "  background:linear-gradient(to bottom,",
-      "    rgba(252,239,82,0.16) 0 10%,rgba(248,232,110,0.16) 10% 20%,",
-      "    rgba(253,253,183,0.16) 20% 30%,rgba(251,244,214,0.16) 30% 40%,",
-      "    rgba(172,120,53,0.16) 40% 50%,rgba(208,170,62,0.16) 50% 60%,",
-      "    rgba(242,204,77,0.16) 60% 70%,rgba(244,219,99,0.16) 70% 80%,",
-      "    rgba(249,237,146,0.16) 80% 90%,rgba(239,216,112,0.16) 90% 100%);",
+      "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
+      "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
+      "    rgba(172,120,53,0.4) 40% 50%,rgba(208,170,62,0.4) 50% 60%,",
+      "    rgba(242,204,77,0.4) 60% 70%,rgba(244,219,99,0.4) 70% 80%,",
+      "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);",
       "  color:#fff;font:bold calc(18px * var(--tc-scale)) sans-serif;",
       "  text-shadow:calc(-1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(-1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000;",
       "  display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;}",
@@ -278,9 +283,9 @@
       // ---- Portrait placement -------------------------------------------------
       // Adjust button spacing slightly when in portrait orientation
       "@media (orientation: portrait) {",
-      "  #tcJoyBase, #tcDpad{left:calc(28px * var(--tc-scale));bottom:calc(72px * var(--tc-scale));}",
-      "  #tcButtons{right:calc(28px * var(--tc-scale));bottom:calc(72px * var(--tc-scale));}",
-      "  #tcMoveToggle, #tcInstall{bottom:calc(208px * var(--tc-scale));}",
+      "  #tcJoyBase, #tcDpad{left:var(--tc-corner-dist);bottom:calc(72px * var(--tc-scale));}",
+      "  #tcButtons{right:var(--tc-corner-dist);bottom:calc(72px * var(--tc-scale));}",
+      "  #tcMoveToggle, #tcInstall{bottom:calc(262px * var(--tc-scale));}",
       "  #tcPause{background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -460,6 +465,8 @@
     }
     el.addEventListener("pointerup", up);
     el.addEventListener("pointercancel", up);
+    el.addEventListener("pointerleave", up);
+    el.addEventListener("lostpointercapture", up);
   }
 
   // Tap-style button: quick down+up (attack, weapon, pause, select, back).
@@ -478,6 +485,8 @@
     }
     el.addEventListener("pointerup", up);
     el.addEventListener("pointercancel", up);
+    el.addEventListener("pointerleave", up);
+    el.addEventListener("lostpointercapture", up);
   }
 
   // ---- Visibility -----------------------------------------------------------

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -152,7 +152,7 @@
       // Joystick base (bottom-left) — same score-system bands, kept subtler
       // (lower alpha) as it covers more play area.
       "#tcJoyBase{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(180px * var(--tc-scale));height:calc(180px * var(--tc-scale));",
-      "  border-radius:50%;border:2px solid #000;box-shadow:0 0 0 1px rgba(0,0,0,0.5);",
+      "  border-radius:50%;border:1px solid #000;box-shadow:0 0 0 1px rgba(0,0,0,0.5);",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -161,7 +161,7 @@
       "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);",
       "  pointer-events:auto;touch-action:none;}",
       "#tcJoyThumb{position:absolute;left:50%;top:50%;width:calc(77px * var(--tc-scale));height:calc(77px * var(--tc-scale));",
-      "  margin:calc(-38px * var(--tc-scale)) 0 0 calc(-38px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
+      "  margin:calc(-38px * var(--tc-scale)) 0 0 calc(-38px * var(--tc-scale));border-radius:50%;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -172,7 +172,7 @@
       "#tcButtons{position:absolute;right:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(200px * var(--tc-scale));height:calc(200px * var(--tc-scale));pointer-events:none;}",
       // 10-band hard-stop gradient sampled from the score display (top->bottom),
       // slightly translucent so gameplay still reads through. Black border.
-      ".tcBtn{position:absolute;width:calc(68px * var(--tc-scale));height:calc(68px * var(--tc-scale));border-radius:50%;border:2px solid #000;",
+      ".tcBtn{position:absolute;width:calc(68px * var(--tc-scale));height:calc(68px * var(--tc-scale));border-radius:50%;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -192,13 +192,13 @@
       "    rgb(249,237,146) 80% 90%,rgb(239,216,112) 90% 100%);}",
       // Diamond layout: 4 buttons at N/E/S/W of the cluster, scaled proportionally.
       // Offsets scale with the button size to maintain spacing ratios.
-      "#tcFire{right:calc(12px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}",     // E (outer right)
-      "#tcJump{right:calc(66px * var(--tc-scale));bottom:calc(12px * var(--tc-scale));}",     // S (bottom)
-      "#tcWeapon{right:calc(66px * var(--tc-scale));bottom:calc(120px * var(--tc-scale));}", // N (top)
-      "#tcAttack{right:calc(120px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}", // W (inner left)
+      "#tcFire{right:calc(11px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}",     // E (outer right)
+      "#tcJump{right:calc(66px * var(--tc-scale));bottom:calc(11px * var(--tc-scale));}",     // S (bottom)
+      "#tcWeapon{right:calc(66px * var(--tc-scale));bottom:calc(121px * var(--tc-scale));}", // N (top)
+      "#tcAttack{right:calc(121px * var(--tc-scale));bottom:calc(66px * var(--tc-scale));}", // W (inner left)
       // Pause (top-center)
       "#tcPause{position:absolute;left:50%;top:calc(6px * var(--tc-scale));transform:translateX(-50%);",
-      "  width:calc(42px * var(--tc-scale));height:calc(30px * var(--tc-scale));border-radius:4px;border:2px solid #000;",
+      "  width:calc(42px * var(--tc-scale));height:calc(30px * var(--tc-scale));border-radius:4px;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.8) 0 10%,rgba(248,232,110,0.8) 10% 20%,",
       "    rgba(253,253,183,0.8) 20% 30%,rgba(251,244,214,0.8) 30% 40%,",
@@ -226,9 +226,9 @@
       "#touchControls.mode-menu #tcPause{display:none;}",
       // D-pad — plus layout, 4 directions only (no diagonals), same footprint
       // as the joystick base. Button size and layout scaled proportionally.
-      "#tcDpad{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(180px * var(--tc-scale));height:calc(180px * var(--tc-scale));",
+      "#tcDpad{position:absolute;left:var(--tc-corner-dist);bottom:var(--tc-corner-dist);width:calc(200px * var(--tc-scale));height:calc(200px * var(--tc-scale));",
       "  pointer-events:none;}",
-      ".tcDbtn{position:absolute;width:calc(59px * var(--tc-scale));height:calc(59px * var(--tc-scale));border-radius:8px;border:2px solid #000;",
+      ".tcDbtn{position:absolute;width:calc(60px * var(--tc-scale));height:calc(60px * var(--tc-scale));border-radius:8px;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -239,20 +239,20 @@
       "  text-shadow:calc(-1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(-1px * var(--tc-scale)) 0 #000,calc(-1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000,calc(1px * var(--tc-scale)) calc(1px * var(--tc-scale)) 0 #000;",
       "  display:flex;align-items:center;justify-content:center;pointer-events:auto;",
       "  touch-action:none;padding:0;}",
-      ".tcDbtn svg{width:24px;height:24px;flex-shrink:0;}",
+      ".tcDbtn svg{width:calc(26px * var(--tc-scale));height:calc(26px * var(--tc-scale));flex-shrink:0;}",
       ".tcDbtn.active{background:linear-gradient(to bottom,",
       "    rgb(252,239,82) 0 10%,rgb(248,232,110) 10% 20%,",
       "    rgb(253,253,183) 20% 30%,rgb(251,244,214) 30% 40%,",
       "    rgb(172,120,53) 40% 50%,rgb(208,170,62) 50% 60%,",
       "    rgb(242,204,77) 60% 70%,rgb(244,219,99) 70% 80%,",
       "    rgb(249,237,146) 80% 90%,rgb(239,216,112) 90% 100%);}",
-      "#tcDup{left:calc(60px * var(--tc-scale));top:calc(6px * var(--tc-scale));}",
-      "#tcDdown{left:calc(60px * var(--tc-scale));top:calc(115px * var(--tc-scale));}",
-      "#tcDleft{left:calc(6px * var(--tc-scale));top:calc(60px * var(--tc-scale));}",
-      "#tcDright{left:calc(115px * var(--tc-scale));top:calc(60px * var(--tc-scale));}",
+      "#tcDup{left:calc(70px * var(--tc-scale));top:calc(8px * var(--tc-scale));}",
+      "#tcDdown{left:calc(70px * var(--tc-scale));top:calc(132px * var(--tc-scale));}",
+      "#tcDleft{left:calc(8px * var(--tc-scale));top:calc(70px * var(--tc-scale));}",
+      "#tcDright{left:calc(132px * var(--tc-scale));top:calc(70px * var(--tc-scale));}",
       // Movement-mode toggle — small button above the movement control, scaled.
       "#tcMoveToggle{position:absolute;left:var(--tc-corner-dist);bottom:calc(var(--tc-corner-dist) + 190px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));opacity:0.85;",
-      "  border-radius:50%;border:2px solid #000;",
+      "  border-radius:50%;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
@@ -266,7 +266,7 @@
       // gold-band style and bottom distance. Hidden once the app is installed
       // (JS removes it) or on desktop.
       "#tcInstall{position:absolute;right:var(--tc-corner-dist);bottom:calc(var(--tc-corner-dist) + 190px * var(--tc-scale));width:calc(42px * var(--tc-scale));height:calc(42px * var(--tc-scale));opacity:0.85;",
-      "  border-radius:50%;border:2px solid #000;",
+      "  border-radius:50%;border:1px solid #000;",
       "  background:linear-gradient(to bottom,",
       "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
       "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",

--- a/OpenClaw/Engine/UserInterface/UserInterface.cpp
+++ b/OpenClaw/Engine/UserInterface/UserInterface.cpp
@@ -2118,13 +2118,26 @@ void ScreenElementMenuItem::ReEvaluateVisibilityCondition()
     else if (m_VisibilityConditionType == "FullscreenOn")
     {
 #ifdef __EMSCRIPTEN__
-        m_bVisible = (bool)EM_ASM_INT({ return document.fullscreenElement ? 1 : 0; });
+        // Hide fullscreen controls on iOS: the browser Fullscreen API is
+        // unsupported there and toggling it crashes the game. Both the ON and
+        // OFF variants stay hidden so no fullscreen button shows on iOS.
+        m_bVisible = (bool)EM_ASM_INT({
+            var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+                (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+            if (iOS) return 0;
+            return document.fullscreenElement ? 1 : 0;
+        });
 #endif
     }
     else if (m_VisibilityConditionType == "FullscreenOff")
     {
 #ifdef __EMSCRIPTEN__
-        m_bVisible = (bool)EM_ASM_INT({ return document.fullscreenElement ? 0 : 1; });
+        m_bVisible = (bool)EM_ASM_INT({
+            var iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+                (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+            if (iOS) return 0;
+            return document.fullscreenElement ? 0 : 1;
+        });
 #else
         m_bVisible = true;
 #endif


### PR DESCRIPTION
## Summary

Makes OpenClaw installable as a PWA for a real fullscreen, app-like experience on mobile and desktop.

**Install & manifest**
- Web app manifest set to fullscreen + landscape, with iOS meta tags and a theme color so the installed app launches without browser chrome.
- First-run onboarding: an install screen (browser-aware Recommended/Optional guidance) shown before the CLAW.REZ upload screen, plus persistent install buttons (desktop toolbar + in-overlay touch button) that hide once installed.
- Cross-browser install handling: native prompt where available, tailored Add-to-Home-Screen (iOS) / Add-to-Dock (macOS) instructions otherwise, and a nudge for Samsung Internet users to install via Chrome (its WebAPK trips an Android "unsafe app" warning that Chrome does not).

**Service worker & resilience**
- Service worker caches the app shell for installability, while leaving WASM/data/range requests to the browser and never caching the version-locked loader (prevents a stale-loader vs. fresh-wasm crash).
- Self-healing safety net: auto-reload on update plus a remote kill-switch so a bad deploy can be recovered without users manually clearing storage.

**Robust first-run**
- CLAW.REZ upload is validated by size and archive header and hard-rejects invalid files (e.g. the commonly mis-uploaded stub), so a wrong file can no longer be stored and boot the game onto a dead screen.
- A load-failure recovery overlay (covering both WASM aborts and thrown boot errors) lets users clear a bad file and re-upload instead of being stuck.
- Private/incognito upload failures now hint at the likely cause.

**Mobile display & controls**
- Respect safe-area insets so the canvas and on-screen controls clear the notch / Dynamic Island / home indicator.
- Re-fit the canvas on orientation change to fix zoom-in when rotating.
- Redesigned, responsive on-screen touch controls (matched d-pad / action clusters, install button) that scale cleanly across screen sizes.
- Hide the Fullscreen option in the Display menu on iOS, where toggling it crashes the game.

Closes #43