### PR TITLE
fix: mobile touch controls — canvas viewport, selection, and D-pad arrows

### DIFF
--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -93,6 +93,23 @@
         container-type: size;
       }
 
+      /* Mobile only (body.mobile set from JS via user-agent) — desktop looks
+         fine and is left untouched.
+         - dvw/dvh: track the visible viewport (100vw/vh extend under the mobile
+           browser UI + safe-area insets with viewport-fit=cover, which cut the
+           canvas off in landscape and shifted it horizontally).
+         - Portrait: pin the canvas to the top instead of vertically centering;
+           landscape keeps it centered. */
+      body.mobile {
+        width: 100dvw;
+        height: 100dvh;
+      }
+      @media (orientation: portrait) {
+        body.mobile .canvas-wrapper {
+          align-items: flex-start;
+        }
+      }
+
       #loading {
         position: absolute;
         top: 50%;
@@ -461,6 +478,17 @@
       if ((navigator.maxTouchPoints && navigator.maxTouchPoints > 0) ||
           "ontouchstart" in window) {
         document.body.classList.add("touch-device");
+      }
+      // Tag real mobile browsers (user-agent) so the viewport/centering fixes
+      // (dvw/dvh, portrait-top) apply ONLY on mobile — desktop layout is fine
+      // and must stay untouched. iPadOS reports as desktop Safari, so also
+      // treat touch + coarse pointer as mobile.
+      var isMobileUA = /Android|iPhone|iPad|iPod|Mobile|Silk|Kindle|Opera Mini/i
+        .test(navigator.userAgent);
+      var isTouchCoarse = (navigator.maxTouchPoints > 0) &&
+        window.matchMedia && window.matchMedia("(pointer: coarse)").matches;
+      if (isMobileUA || isTouchCoarse) {
+        document.body.classList.add("mobile");
       }
     </script>
     <!-- Asset Upload UI (shown on first run) -->

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -125,6 +125,11 @@
         /* Suppress browser scroll/pinch/double-tap gestures so Pointer Events
            reach the game unmodified. */
         touch-action: none;
+        /* Repeatedly tapping the touch buttons was selecting the canvas on
+           mobile — disable text selection and the iOS callout on it. */
+        user-select: none;
+        -webkit-user-select: none;
+        -webkit-touch-callout: none;
       }
 
       canvas:focus {

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -245,10 +245,13 @@
     root.innerHTML =
       '<div id="tcJoyBase"><div id="tcJoyThumb"></div></div>' +
       '<div id="tcDpad">' +
+      // Use U+25C4/25BA (◄ ►) not U+25C0/25B6 (◀ ▶): the latter have emoji
+      // presentation and render as coloured OS emoji on mobile. These match the
+      // text-default ▲ ▼ family.
       '  <div class="tcDbtn" id="tcDup">▲</div>' +
       '  <div class="tcDbtn" id="tcDdown">▼</div>' +
-      '  <div class="tcDbtn" id="tcDleft">◀</div>' +
-      '  <div class="tcDbtn" id="tcDright">▶</div>' +
+      '  <div class="tcDbtn" id="tcDleft">◄</div>' +
+      '  <div class="tcDbtn" id="tcDright">►</div>' +
       "</div>" +
       '<div id="tcMoveToggle">STICK</div>' +
       '<div id="tcButtons">' +


### PR DESCRIPTION
## Summary

- Fix the mobile canvas viewport: with viewport-fit=cover, 100vw/100vh extended under the browser UI and safe-area insets, cutting the canvas off in landscape and shifting it slightly right. Mobile now sizes with dvw/dvh to track the visible viewport.
- Orientation-aware layout on mobile: portrait pins the canvas to the top, landscape keeps it centered.
- Prevent the game canvas from being text-selected when repeatedly tapping the on-screen touch buttons.
- Fix the D-pad left/right arrows rendering as coloured OS emoji on mobile (used text-presentation glyphs to match up/down).

All mobile layout changes are gated behind a user-agent check (with a touch + coarse-pointer fallback for iPadOS), so desktop is unaffected.