### PR TITLE
fix: pin canvas to top in mobile portrait

### DIFF
--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -105,7 +105,11 @@
         height: 100dvh;
       }
       @media (orientation: portrait) {
-        body.mobile .canvas-wrapper {
+        /* Pin the canvas to the top. Both the wrapper AND #canvasContainer are
+           full-height flex boxes that vertically center by default, so the
+           inner one must also align to the start or it re-centers the canvas. */
+        body.mobile .canvas-wrapper,
+        body.mobile #canvasContainer {
           align-items: flex-start;
         }
       }

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -62,8 +62,14 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
+        /* vw/vh fallback; dvw/dvh track the actually-visible viewport (100vw/vh
+           extend under the mobile browser UI + safe-area insets with
+           viewport-fit=cover, cutting the canvas off in landscape and shifting
+           it right). On desktop dvh == vh, so it's a no-op there. */
         width: 100vw;
         height: 100vh;
+        width: 100dvw;
+        height: 100dvh;
         transition:
           background-color 0.3s,
           color 0.3s;
@@ -93,25 +99,51 @@
         container-type: size;
       }
 
-      /* Mobile only (body.mobile set from JS via user-agent) — desktop looks
-         fine and is left untouched.
-         - dvw/dvh: track the visible viewport (100vw/vh extend under the mobile
-           browser UI + safe-area insets with viewport-fit=cover, which cut the
-           canvas off in landscape and shifted it horizontally).
-         - Portrait: pin the canvas to the top instead of vertically centering;
-           landscape keeps it centered. */
-      body.mobile {
-        width: 100dvw;
-        height: 100dvh;
-      }
+      /* Portrait: pin the canvas to the top instead of vertically centering.
+         Both the wrapper AND #canvasContainer are full-height flex boxes that
+         center by default, so the inner one must also align to start. Desktop
+         monitors are landscape, so this effectively only affects mobile. */
       @media (orientation: portrait) {
-        /* Pin the canvas to the top. Both the wrapper AND #canvasContainer are
-           full-height flex boxes that vertically center by default, so the
-           inner one must also align to the start or it re-centers the canvas. */
-        body.mobile .canvas-wrapper,
-        body.mobile #canvasContainer {
+        /* Prefix with .game-container to out-specify the base #canvasContainer
+           rule (equal specificity would lose on source order, leaving it
+           centered). */
+        .game-container .canvas-wrapper,
+        .game-container #canvasContainer {
           align-items: flex-start;
         }
+      }
+
+      /* Rotate prompt: browsers can't force device rotation from a tab, so on
+         very narrow portrait screens (< 375px wide) show a full-screen overlay
+         asking the player to rotate. Hidden otherwise. */
+      #rotatePrompt {
+        display: none;
+      }
+      @media (orientation: portrait) and (max-width: 374px) {
+        #rotatePrompt {
+          position: fixed;
+          inset: 0;
+          z-index: 10000;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 16px;
+          background: #000;
+          color: #fde46b;
+          font-family: sans-serif;
+          font-weight: bold;
+          text-align: center;
+          padding: 24px;
+        }
+        #rotatePrompt .rotate-icon {
+          font-size: 48px;
+          animation: rotateHint 1.6s ease-in-out infinite;
+        }
+      }
+      @keyframes rotateHint {
+        0%, 40% { transform: rotate(0deg); }
+        60%, 100% { transform: rotate(-90deg); }
       }
 
       #loading {
@@ -483,18 +515,14 @@
           "ontouchstart" in window) {
         document.body.classList.add("touch-device");
       }
-      // Tag real mobile browsers (user-agent) so the viewport/centering fixes
-      // (dvw/dvh, portrait-top) apply ONLY on mobile — desktop layout is fine
-      // and must stay untouched. iPadOS reports as desktop Safari, so also
-      // treat touch + coarse pointer as mobile.
-      var isMobileUA = /Android|iPhone|iPad|iPod|Mobile|Silk|Kindle|Opera Mini/i
-        .test(navigator.userAgent);
-      var isTouchCoarse = (navigator.maxTouchPoints > 0) &&
-        window.matchMedia && window.matchMedia("(pointer: coarse)").matches;
-      if (isMobileUA || isTouchCoarse) {
-        document.body.classList.add("mobile");
-      }
     </script>
+
+    <!-- Rotate prompt: shown on narrow portrait screens (< 375px wide) -->
+    <div id="rotatePrompt">
+      <div class="rotate-icon">📱</div>
+      <div>Please rotate your device to landscape to play.</div>
+    </div>
+
     <!-- Asset Upload UI (shown on first run) -->
     <section id="assetUpload" style="display: none;">
       <h2>First Time Setup</h2>

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -232,6 +232,25 @@
       // Show joystick OR d-pad based on the movement mode class on the root.
       "#touchControls.move-joystick #tcDpad{display:none;}",
       "#touchControls.move-dpad #tcJoyBase{display:none;}",
+
+      // ---- Portrait placement -------------------------------------------------
+      // Original button/cluster SIZES kept; only the cluster POSITIONS change:
+      // 15px from the side borders, 60px from the bottom. Internal button
+      // offsets are unchanged (sizes unchanged, so the diamond/plus still tile).
+      "@media (orientation: portrait) {",
+      "  #tcJoyBase, #tcDpad{left:15px;bottom:60px;}",
+      "  #tcButtons{right:15px;bottom:60px;}",
+      // toggle sits above the 140px movement control (top at 60+140=200), ~8px gap
+      "  #tcMoveToggle{left:15px;bottom:208px;}",
+      // pause: same translucency as the other buttons (0.4); JS sets its top to
+      // 15px below the (dynamically-sized) canvas.
+      "  #tcPause{background:linear-gradient(to bottom,",
+      "    rgba(252,239,82,0.4) 0 10%,rgba(248,232,110,0.4) 10% 20%,",
+      "    rgba(253,253,183,0.4) 20% 30%,rgba(251,244,214,0.4) 30% 40%,",
+      "    rgba(172,120,53,0.4) 40% 50%,rgba(208,170,62,0.4) 50% 60%,",
+      "    rgba(242,204,77,0.4) 60% 70%,rgba(244,219,99,0.4) 70% 80%,",
+      "    rgba(249,237,146,0.4) 80% 90%,rgba(239,216,112,0.4) 90% 100%);}",
+      "}",
     ].join("");
     var style = document.createElement("style");
     style.id = "touchControlsStyles";
@@ -418,6 +437,20 @@
     return "";
   }
 
+  // Portrait only: place the pause button 15px below the canvas (its height is
+  // JS-set, so CSS can't know where its bottom is). Otherwise clear the inline
+  // top so the CSS default (top:6px) applies.
+  function positionPause() {
+    var pause = document.getElementById("tcPause");
+    if (!pause) return;
+    var portrait = window.matchMedia &&
+      window.matchMedia("(orientation: portrait)").matches;
+    if (!portrait) { pause.style.top = ""; return; }
+    var canvas = document.getElementById("canvas");
+    if (!canvas) return;
+    pause.style.top = Math.round(canvas.getBoundingClientRect().bottom + 15) + "px";
+  }
+
   function setupVisibility(root) {
     var mode = null;
     function tick() {
@@ -429,6 +462,7 @@
         root.classList.toggle("mode-gameplay", next === "gameplay");
         root.classList.toggle("mode-menu", next === "menu");
       }
+      positionPause();
       setTimeout(tick, 200);
     }
     tick();


### PR DESCRIPTION
## Summary

- In mobile portrait, the canvas was still vertically centered instead of pinned to the top: the prior rule only aligned .canvas-wrapper, but the canvas lives inside #canvasContainer, another full-height flex box that re-centered it. Apply align-items:flex-start to both.
- Remains gated behind the body.mobile user-agent check, so desktop layout is unaffected.