### PR TITLE
feat: add weapon select sound effect

### DIFF
--- a/OpenClaw/Engine/UserInterface/HumanView.cpp
+++ b/OpenClaw/Engine/UserInterface/HumanView.cpp
@@ -755,6 +755,12 @@ void HumanView::AmmoTypeUpdatedDelegate(IEventDataPtr pEventData)
         {
             LOG_ERROR("Unknown ammo type: " + ToStr(pCastEventData->GetAmmoType()));
         }
+
+        // Play weapon select sound
+        SoundInfo selectSound("/GAME/SOUNDS/SELECT.WAV");
+        selectSound.soundVolume = 100;
+        shared_ptr<EventData_Request_Play_Sound> pSoundEvent(new EventData_Request_Play_Sound(selectSound));
+        IEventMgr::Get()->VTriggerEvent(pSoundEvent);
     }
     else
     {


### PR DESCRIPTION
## Summary
- Play SELECT.WAV sound when switching weapons, matching original game behavior
- Triggers sound through event system when ammo type changes
- Weapon cycling now has audio feedback on all weapon types