### PR TITLE
fix: silence false-positive warnings and remove debug logs

### DIFF
--- a/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
@@ -32,6 +32,7 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
 
     WapPal* palette = g_pApp->GetCurrentPalette();
     m_HasImagePathElements = false;
+    m_AllImageDirsEmpty = true;
 
     for (TiXmlElement* pImagePathElem = pXmlData->FirstChildElement("ImagePath");
         pImagePathElem; pImagePathElem = pImagePathElem->NextSiblingElement("ImagePath"))
@@ -61,6 +62,8 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
         {
             continue;
         }
+
+        m_AllImageDirsEmpty = false;
 
         // Remove all images which dont conform to the given pattern
         // This affects probably only object with "DoNothing" logic
@@ -136,8 +139,9 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
         }
     }
 
-    // Only warn if actor explicitly specified ImagePath elements but none were loaded
-    if (m_HasImagePathElements && m_ImageMap.empty())
+    // Only warn if actor specified ImagePath elements with files but none were loaded
+    // Don't warn if all image directories were empty (expected for some decorations)
+    if (m_HasImagePathElements && m_ImageMap.empty() && !m_AllImageDirsEmpty)
     {
         LOG_WARNING("Image map for render component is empty. Actor type: " + std::string(pXmlData->Parent()->ToElement()->Attribute("Type")));
     }
@@ -277,7 +281,7 @@ bool ActorRenderComponent::VDelegateInit(TiXmlElement* pXmlData)
     {
         if (m_ImageMap.empty())
         {
-            if (m_HasImagePathElements)
+            if (m_HasImagePathElements && !m_AllImageDirsEmpty)
             {
                 LOG_WARNING("Creating actor render component without valid image.");
             }

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
@@ -31,10 +31,13 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
     assert(pXmlData != NULL);
 
     WapPal* palette = g_pApp->GetCurrentPalette();
+    bool hasImagePathElements = false;
 
     for (TiXmlElement* pImagePathElem = pXmlData->FirstChildElement("ImagePath");
         pImagePathElem; pImagePathElem = pImagePathElem->NextSiblingElement("ImagePath"))
     {
+        hasImagePathElements = true;
+
         if (palette == NULL)
         {
             LOG_ERROR("Attempting to create BaseRenderComponent without existing palette");
@@ -107,7 +110,7 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
                 imageNameKey = "frame" + Util::ConvertToThreeDigitsString(imageNameNumStr);
             }*/
             // Just reconstruct it...
-            if (imageNameKey.length() > 3 /* Hack for checkpointflag */ || 
+            if (imageNameKey.length() > 3 /* Hack for checkpointflag */ ||
                 std::string(pXmlData->Parent()->ToElement()->Attribute("Type")) == "GAME_CHECKPOINTFLAG")
             {
                 std::string tmp = imageNameKey;
@@ -127,7 +130,8 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
         }
     }
 
-    if (m_ImageMap.empty())
+    // Only warn if actor explicitly specified ImagePath elements but none were loaded
+    if (hasImagePathElements && m_ImageMap.empty())
     {
         LOG_WARNING("Image map for render component is empty. Actor type: " + std::string(pXmlData->Parent()->ToElement()->Attribute("Type")));
     }

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
@@ -637,7 +637,6 @@ bool TilePlaneRenderComponent::VDelegateInit(TiXmlElement* pXmlData)
         LOG_ERROR("Tiles are missing.");
         return false;
     }
-    PROFILE_CPU("PLANE CREATION");
     int32 tileIdx = 0;
 
     TileList tileList;

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
@@ -31,12 +31,12 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
     assert(pXmlData != NULL);
 
     WapPal* palette = g_pApp->GetCurrentPalette();
-    bool hasImagePathElements = false;
+    m_HasImagePathElements = false;
 
     for (TiXmlElement* pImagePathElem = pXmlData->FirstChildElement("ImagePath");
         pImagePathElem; pImagePathElem = pImagePathElem->NextSiblingElement("ImagePath"))
     {
-        hasImagePathElements = true;
+        m_HasImagePathElements = true;
 
         if (palette == NULL)
         {
@@ -131,7 +131,7 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
     }
 
     // Only warn if actor explicitly specified ImagePath elements but none were loaded
-    if (hasImagePathElements && m_ImageMap.empty())
+    if (m_HasImagePathElements && m_ImageMap.empty())
     {
         LOG_WARNING("Image map for render component is empty. Actor type: " + std::string(pXmlData->Parent()->ToElement()->Attribute("Type")));
     }
@@ -271,7 +271,10 @@ bool ActorRenderComponent::VDelegateInit(TiXmlElement* pXmlData)
     {
         if (m_ImageMap.empty())
         {
-            LOG_WARNING("Creating actor render component without valid image.");
+            if (m_HasImagePathElements)
+            {
+                LOG_WARNING("Creating actor render component without valid image.");
+            }
             return true;
         }
         m_CachedImage = m_ImageMap.begin()->second;

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.cpp
@@ -56,6 +56,12 @@ bool BaseRenderComponent::VInit(TiXmlElement* pXmlData)
         std::vector<std::string> matchingPathNames =
             g_pApp->GetResourceCache()->GetAllFilesInDirectory(imageDir.c_str());
 
+        // Skip if directory is empty — some level props (decorations) may have empty image directories
+        if (matchingPathNames.empty())
+        {
+            continue;
+        }
+
         // Remove all images which dont conform to the given pattern
         // This affects probably only object with "DoNothing" logic
         // Compute everything in lowercase to assure compatibility with everything in the engine

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.h
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.h
@@ -43,6 +43,7 @@ protected:
     virtual void VCreateInheritedXmlElements(TiXmlElement* pBaseElement) = 0;
 
     ImageMap m_ImageMap;
+    bool m_HasImagePathElements;
 
     shared_ptr<SceneNode> m_pSceneNode;
 

--- a/OpenClaw/Engine/Actor/Components/RenderComponent.h
+++ b/OpenClaw/Engine/Actor/Components/RenderComponent.h
@@ -44,6 +44,7 @@ protected:
 
     ImageMap m_ImageMap;
     bool m_HasImagePathElements;
+    bool m_AllImageDirsEmpty;
 
     shared_ptr<SceneNode> m_pSceneNode;
 

--- a/OpenClaw/Engine/GameApp/BaseGameLogic.cpp
+++ b/OpenClaw/Engine/GameApp/BaseGameLogic.cpp
@@ -309,9 +309,6 @@ void RenderLoadingScreen(shared_ptr<Image> pBackground, SDL_Rect& renderRect, Po
 
 bool BaseGameLogic::VLoadGame(const char* xmlLevelResource)
 {
-    PROFILE_CPU("GAME LOADING");
-    PROFILE_MEMORY("GAME LOADING");
-
     // Stop all audio
     g_pApp->GetAudio()->StopAllSounds();
 

--- a/OpenClaw/Engine/UserInterface/HumanView.cpp
+++ b/OpenClaw/Engine/UserInterface/HumanView.cpp
@@ -715,16 +715,19 @@ void HumanView::AmmoUpdatedDelegate(IEventDataPtr pEventData)
     {
         shared_ptr<EventData_Updated_Ammo> pCastEventData = static_pointer_cast<EventData_Updated_Ammo>(pEventData);
 
+        // Validate ammo type first
+        if (pCastEventData->GetAmmoType() < AmmoType_Pistol || pCastEventData->GetAmmoType() >= AmmoType_Max)
+        {
+            LOG_ERROR("Unknown ammo type: " + ToStr(pCastEventData->GetAmmoType()));
+            return;
+        }
+
         // TODO: This should be more generic
         if ((pCastEventData->GetAmmoType() == AmmoType_Pistol && m_pHUD->IsElementVisible("pistol")) ||
             (pCastEventData->GetAmmoType() == AmmoType_Magic && m_pHUD->IsElementVisible("magic")) ||
             (pCastEventData->GetAmmoType() == AmmoType_Dynamite && m_pHUD->IsElementVisible("dynamite")))
-        { 
-            m_pHUD->UpdateAmmo(pCastEventData->GetAmmoCount());
-        }
-        else if (pCastEventData->GetAmmoType() <= AmmoType_None || pCastEventData->GetAmmoType() >= AmmoType_Max)
         {
-            LOG_ERROR("Unknown ammo type: " + ToStr(pCastEventData->GetAmmoType()));
+            m_pHUD->UpdateAmmo(pCastEventData->GetAmmoCount());
         }
     }
     else
@@ -736,8 +739,9 @@ void HumanView::AmmoUpdatedDelegate(IEventDataPtr pEventData)
 void HumanView::AmmoTypeUpdatedDelegate(IEventDataPtr pEventData)
 {
     shared_ptr<EventData_Updated_Ammo_Type> pCastEventData = static_pointer_cast<EventData_Updated_Ammo_Type>(pEventData);
-    if (pCastEventData->GetAmmoType() >= AmmoType_Max)
+    if (pCastEventData->GetAmmoType() < AmmoType_Pistol || pCastEventData->GetAmmoType() >= AmmoType_Max)
     {
+        LOG_ERROR("Unknown ammo type: " + ToStr(pCastEventData->GetAmmoType()));
         return;
     }
 
@@ -751,10 +755,6 @@ void HumanView::AmmoTypeUpdatedDelegate(IEventDataPtr pEventData)
         if (pCastEventData->GetAmmoType() == AmmoType_Pistol) { m_pHUD->SetElementVisible("pistol", true); }
         else if (pCastEventData->GetAmmoType() == AmmoType_Magic) { m_pHUD->SetElementVisible("magic", true); }
         else if (pCastEventData->GetAmmoType() == AmmoType_Dynamite) { m_pHUD->SetElementVisible("dynamite", true); }
-        else
-        {
-            LOG_ERROR("Unknown ammo type: " + ToStr(pCastEventData->GetAmmoType()));
-        }
 
         // Play weapon select sound
         SoundInfo selectSound("/GAME/SOUNDS/SELECT.WAV");

--- a/OpenClaw/Engine/Util/Converters.cpp
+++ b/OpenClaw/Engine/Util/Converters.cpp
@@ -5,7 +5,6 @@ void FixupWwdObject(WwdObject* pObj, int levelNumber);
 
 TiXmlElement* WwdToXml(WapWwd* wapWwd, int levelNumber)
 {
-    PROFILE_CPU("WWD->XML");
     TiXmlDocument xmlDoc;
 
     //----- [Level]

--- a/OpenClaw/Engine/Util/Converters.h
+++ b/OpenClaw/Engine/Util/Converters.h
@@ -1215,32 +1215,39 @@ inline TiXmlElement* WwdObjectToXml(WwdObject* wwdObject, std::string& imagesRoo
             position,
             def);
     }
-    else
-    {
-        static std::vector<std::string> s_ReportedUnknownLogicsList;
-
-        bool isAlreadyReported = false;
-        for (std::string &unkLogic : s_ReportedUnknownLogicsList)
-        {
-            if (unkLogic == logic)
-            {
-                isAlreadyReported = true;
-                break;
-            }
-        }
-
-        if (!isAlreadyReported)
-        {
-            s_ReportedUnknownLogicsList.push_back(logic);
-            LOG_WARNING("Unknown logic: " + logic);
-        }
-    }
 
     // If we have actor prototype defined and not processed, it is a failure on our side
     if (actorProto != ActorPrototype_None)
     {
         SAFE_DELETE(pActorElem);
         return NULL;
+    }
+
+    // Static decoration objects with no behavior — just return the render-only XML
+    // This silently handles them without logging an "Unknown logic" warning
+    if (logic == "DoNothing" || logic == "DoNothingNormal" ||
+        logic == "BehindAniCandy" || logic == "FrontCandy" ||
+        logic == "BehindCandy" || logic == "FrontAniCandy")
+    {
+        return pActorElem;
+    }
+
+    // Log unknown logic only for unhandled types (not DoNothing)
+    static std::vector<std::string> s_ReportedUnknownLogicsList;
+    bool isAlreadyReported = false;
+    for (std::string &unkLogic : s_ReportedUnknownLogicsList)
+    {
+        if (unkLogic == logic)
+        {
+            isAlreadyReported = true;
+            break;
+        }
+    }
+
+    if (!isAlreadyReported)
+    {
+        s_ReportedUnknownLogicsList.push_back(logic);
+        LOG_WARNING("Unknown logic: " + logic);
     }
 
     return pActorElem;


### PR DESCRIPTION
## Summary

- Fix false "Unknown ammo type" errors when valid ammo types are received while their HUD element is hidden
- Silence spurious render-component warnings for level decorations whose image directories are legitimately empty (e.g. candelabra)
- Stop logging "Unknown logic" for static decoration objects (DoNothing, DoNothingNormal, and the Candy variants), which are render-only props with no behavior
- Remove leftover debug profiling logs (WWD->XML, PLANE CREATION, GAME LOADING timings)
