### PR TITLE
feat: smooth rendering via position interpolation

### DIFF
--- a/OpenClaw/Engine/GameApp/BaseGameApp.cpp
+++ b/OpenClaw/Engine/GameApp/BaseGameApp.cpp
@@ -68,10 +68,7 @@ BaseGameApp::BaseGameApp() {
   m_accumulator = 0.0;
   m_fixedTimestep = 1.0 / 60.0;  // 60 updates per second
   m_alpha = 0.0;
-
-  // Initialize render rate cap (overwritten from options once they load)
-  m_renderAccumulator = 0.0;
-  m_renderInterval = 1.0 / 60.0;
+  m_logicTick = 0;
 }
 
 void BaseGameApp::OnAppEvent(const AppEvent &event) {
@@ -249,14 +246,6 @@ bool BaseGameApp::Initialize(int argc, char **argv) {
     m_fixedTimestep = 1.0 / 60.0;
   }
 
-  // Configure render rate cap based on settings
-  if (m_GlobalOptions.renderFps > 0) {
-    m_renderInterval = 1.0 / static_cast<double>(m_GlobalOptions.renderFps);
-  } else {
-    LOG_WARNING("Invalid renderFps value, using default 30 FPS");
-    m_renderInterval = 1.0 / 30.0;
-  }
-
   m_IsRunning = true;
 
   return true;
@@ -405,7 +394,6 @@ void BaseGameApp::StepLoop() {
 
     // Accumulate time for fixed timestep updates
     m_accumulator += frameTime;
-    m_renderAccumulator += frameTime;
 
 // Handle all input events
 #ifdef __EMSCRIPTEN__
@@ -447,6 +435,11 @@ void BaseGameApp::StepLoop() {
         IEventMgr::Get()->VUpdate(
             20); // Allow event queue to process for up to 20 ms
 
+        // Advance the logic-tick counter. Scene nodes stamp this when their
+        // position changes, so rendering only interpolates actors that actually
+        // moved on the current tick (stationary actors render flat, no shake).
+        m_logicTick++;
+
         // Convert fixed timestep back to milliseconds for game logic
         uint32 fixedDeltaMs = static_cast<uint32>(m_fixedTimestep * 1000.0);
         m_pGame->VOnUpdate(fixedDeltaMs);
@@ -454,26 +447,20 @@ void BaseGameApp::StepLoop() {
         m_accumulator -= m_fixedTimestep;
       }
 
-      // Calculate interpolation factor for smooth rendering
+      // Interpolation factor (0..1): how far this render frame sits between the
+      // previous and next fixed logic tick. Actors are drawn at the lerp of their
+      // previous/current positions by this alpha, so motion stays smooth even when
+      // the display refreshes faster than the fixed logic rate.
       m_alpha = m_accumulator / m_fixedTimestep;
 
-      // Cap render rate independently of the display refresh rate. The main loop
-      // fires at the monitor's refresh (via requestAnimationFrame), but rendering
-      // more often than renderFps is wasted work since game state only changes at
-      // gameLogicFps. Skip rendering until enough time has accumulated.
-      if (m_renderAccumulator >= m_renderInterval) {
-        uint32 fixedDeltaMs = static_cast<uint32>(m_fixedTimestep * 1000.0);
-        for (auto &pGameView : m_pGame->m_GameViews) {
-          // PROFILE_CPU("ONLY RENDER");
-          pGameView->VOnRender(fixedDeltaMs);
-        }
-
-        // Subtract the interval (not reset to 0) to keep render cadence steady
-        m_renderAccumulator -= m_renderInterval;
-        // Guard against unbounded growth after a long stall
-        if (m_renderAccumulator >= m_renderInterval) {
-          m_renderAccumulator = 0.0;
-        }
+      // Render every frame. The main loop is driven by requestAnimationFrame, which
+      // is already synced to the display's refresh rate — so rendering adapts to the
+      // device automatically (60Hz, 165Hz, VRR, ...) with no artificial cap. Motion
+      // smoothness comes from interpolation (m_alpha) rather than raw render count.
+      uint32 fixedDeltaMs = static_cast<uint32>(m_fixedTimestep * 1000.0);
+      for (auto &pGameView : m_pGame->m_GameViews) {
+        // PROFILE_CPU("ONLY RENDER");
+        pGameView->VOnRender(fixedDeltaMs);
       }
 
       // m_pGame->VRenderDiagnostics();

--- a/OpenClaw/Engine/GameApp/BaseGameApp.h
+++ b/OpenClaw/Engine/GameApp/BaseGameApp.h
@@ -150,7 +150,6 @@ struct GlobalOptions {
     loadAllLevelSaves = false;
     showPosition = true;
     gameLogicFps = 60;  // Game logic update rate (independent of display FPS)
-    renderFps = 60;     // Max render rate; capped independently of display refresh
   }
 
   double maxJumpSpeed;
@@ -173,7 +172,6 @@ struct GlobalOptions {
   bool loadAllLevelSaves;
   bool showPosition;
   int gameLogicFps;  // Target game logic update rate (default: 60)
-  int renderFps;     // Max render rate, capped independently of display refresh (default: 60)
 };
 
 struct ControlOptions {
@@ -265,6 +263,16 @@ public:
   Point GetScale();
   void SetScale(Point scale);
   uint32 GetWindowFlags();
+
+  // Interpolation factor (0..1) for how far the current render frame is between
+  // the previous and next fixed logic tick. Used to smoothly render motion at
+  // refresh rates higher than the fixed logic rate.
+  double GetInterpolationAlpha() const { return m_alpha; }
+
+  // Monotonic logic-tick counter. Scene nodes stamp this when their position
+  // changes so rendering can tell whether an actor moved on the current tick
+  // (and should interpolate) or is stationary (and should render flat).
+  uint32 GetLogicTick() const { return m_logicTick; }
 
   inline SDL_Renderer *GetRenderer() const { return m_pRenderer; }
   // TODO: Memory leak most likely
@@ -422,11 +430,8 @@ private:
   // Fixed timestep variables for frame-rate independent game logic
   double m_accumulator;         // Accumulated time for fixed updates
   double m_fixedTimestep;       // Target physics/logic timestep in seconds (e.g., 1/60 for 60Hz)
-  double m_alpha;               // Interpolation factor for rendering between updates
-
-  // Render rate cap, independent of display refresh
-  double m_renderAccumulator;   // Accumulated time since last render
-  double m_renderInterval;      // Min seconds between renders (e.g., 1/60 for 60fps cap)
+  double m_alpha;               // Interpolation factor (0..1) for rendering between logic ticks
+  uint32 m_logicTick;           // Monotonic count of fixed logic ticks executed
 };
 
 extern BaseGameApp *g_pApp;

--- a/OpenClaw/Engine/Scene/ActorSceneNode.cpp
+++ b/OpenClaw/Engine/Scene/ActorSceneNode.cpp
@@ -2,6 +2,7 @@
 #include "ActorSceneNode.h"
 #include "../Actor/Components/RenderComponent.h"
 #include "../Graphics2D/Image.h"
+#include "../GameApp/BaseGameApp.h"
 
 SDL2ActorSceneNode::SDL2ActorSceneNode(const uint32 actorId,
     BaseRenderComponent* pRenderComponent,
@@ -53,10 +54,13 @@ void SDL2ActorSceneNode::VRender(Scene* pScene)
     const SDL_Rect cameraRect = pCamera->GetCameraRect();
     int32 offsetX = arc->IsMirrored() ? -actorImage->GetOffsetX() : actorImage->GetOffsetX();
     int32 offsetY = arc->IsInverted() ? -actorImage->GetOffsetY() : actorImage->GetOffsetY();
+    // Interpolate between the previous and current logic-tick position so motion is
+    // smooth when the display refreshes faster than the fixed logic rate.
+    const Point renderPos = m_Properties.GetInterpolatedPosition(g_pApp->GetInterpolationAlpha(), g_pApp->GetLogicTick());
     SDL_Rect renderRect =
     {
-        (int)m_Properties.GetPosition().x - actorImage->GetWidth() / 2  + offsetX - cameraRect.x,
-        (int)m_Properties.GetPosition().y - actorImage->GetHeight() / 2 + offsetY - cameraRect.y,
+        (int)renderPos.x - actorImage->GetWidth() / 2  + offsetX - cameraRect.x,
+        (int)renderPos.y - actorImage->GetHeight() / 2 + offsetY - cameraRect.y,
         actorImage->GetWidth(),
         actorImage->GetHeight()
     };

--- a/OpenClaw/Engine/Scene/SceneNodes.cpp
+++ b/OpenClaw/Engine/Scene/SceneNodes.cpp
@@ -27,6 +27,7 @@ SceneNode::SceneNode(uint32 actorId, BaseRenderComponent* renderComponent, Rende
     m_Properties.m_Orientation = 0;
     m_Properties.m_Name = ""; // TODO
     m_Properties.m_Position = position;
+    m_Properties.m_PrevPosition = position;  // seed so first frame doesn't lerp from origin
     m_Properties.m_RenderPass = renderPass;
     m_Properties.m_ZCoord = zCoord;
     m_pRenderComponent = renderComponent;
@@ -137,7 +138,24 @@ void SceneNode::VSetPosition(const Point &position) {
     if (m_pParent) {
         m_pParent->VOnBeforeChildrenModifyPosition(this, position);
     }
+    // Shift current -> previous so rendering can interpolate between the two most
+    // recent logic-tick positions. VSetPosition is driven once per tick by the
+    // EventData_Move_Actor delegate. Stamp the current logic tick so the renderer
+    // knows this actor moved *this* tick (and should interpolate); actors that did
+    // not move keep a stale stamp and render flat instead of shaking.
+    m_Properties.m_PrevPosition = m_Properties.m_Position;
     m_Properties.m_Position = position;
+    m_Properties.m_LastMoveTick = g_pApp->GetLogicTick();
+
+    // Teleport guard: on respawn / level load / warp the actor jumps a large
+    // distance in a single tick. Interpolating that would streak the sprite
+    // across the screen for one frame, so snap instead (prev == current).
+    const double SNAP_THRESHOLD = 256.0;
+    if (std::abs(m_Properties.m_Position.x - m_Properties.m_PrevPosition.x) > SNAP_THRESHOLD ||
+        std::abs(m_Properties.m_Position.y - m_Properties.m_PrevPosition.y) > SNAP_THRESHOLD)
+    {
+        m_Properties.m_PrevPosition = m_Properties.m_Position;
+    }
 }
 
 //=================================================================================================
@@ -436,7 +454,9 @@ void CameraNode::SetViewPosition(Scene* pScene)
     // If there is a target, make sure target is in the center of the camera
     if (m_pTarget)
     {
-        Point targetPos = m_pTarget->VGetProperties()->GetPosition();
+        // Use the target's interpolated position so the camera stays glued to the
+        // smoothly-rendered player sprite instead of jittering against it.
+        Point targetPos = m_pTarget->VGetProperties()->GetInterpolatedPosition(g_pApp->GetInterpolationAlpha(), g_pApp->GetLogicTick());
         // Center camera
         Point scale = g_pApp->GetScale();
         Point cameraPos = targetPos - Point((m_Width / 2) / scale.x, (m_Height / 2) / scale.y);

--- a/OpenClaw/Engine/Scene/SceneNodes.h
+++ b/OpenClaw/Engine/Scene/SceneNodes.h
@@ -55,6 +55,21 @@ public:
     const uint32& GetActorId() const { return m_ActorId; }
     const char* GetName() const { return m_Name.c_str(); }
     const Point& GetPosition() const { return m_Position; }
+    // Position for rendering. When the actor moved on the current logic tick, blend
+    // between its previous and current position by alpha (0..1) for smooth motion at
+    // refresh rates above the logic rate. When it did NOT move this tick (stationary
+    // actor), render its current position flat — otherwise alpha would keep sweeping
+    // between two stale positions and the sprite would visibly shake.
+    Point GetInterpolatedPosition(double alpha, uint32 currentTick) const
+    {
+        if (m_LastMoveTick != currentTick)
+        {
+            return m_Position;
+        }
+        return Point(
+            m_PrevPosition.x + (m_Position.x - m_PrevPosition.x) * alpha,
+            m_PrevPosition.y + (m_Position.y - m_PrevPosition.y) * alpha);
+    }
     const int32 GetOrientation() const { return m_Orientation; }
     const int32 GetZCoord() const { return m_ZCoord; }
 
@@ -64,6 +79,8 @@ protected:
     uint32          m_ActorId;
     std::string     m_Name;
     Point           m_Position;
+    Point           m_PrevPosition;
+    uint32          m_LastMoveTick = 0;  // logic tick on which m_Position last changed
     RenderPass      m_RenderPass;
     int32           m_Orientation;
     int32           m_ZCoord;


### PR DESCRIPTION
## Summary

- Render actors at the interpolated position between the previous and current fixed logic tick, blended by the accumulator alpha the loop already computed but never used. Motion is now smooth at any display refresh rate while game logic stays locked at 60Hz.
- Render every requestAnimationFrame tick instead of capping the rate. Since RAF is display-synced, this adapts automatically to the device (60Hz, 165Hz, VRR, ...) with no hardcoded frame cap, and re-paces live if the refresh rate changes without a reload.
- Only interpolate actors that moved on the current tick, tracked via a per-node last-move logic-tick stamp, so stationary sprites (checkpoint flags, idle enemies, scenery) render flat instead of shaking. Large single-tick jumps (respawn, warp, level load) snap instead of interpolating.