### PR TITLE
fix: block player input while quick menu is open

### DIFF
--- a/OpenClaw/ActorController.cpp
+++ b/OpenClaw/ActorController.cpp
@@ -58,6 +58,22 @@ void ActorController::HandleAction(ActionType actionType)
 
 void ActorController::OnUpdate(uint32 msDiff)
 {
+    // Don't drive the player while a menu (e.g. the ingame quick menu) is open.
+    // OnUpdate reads raw held-key state every frame, so even keys held down
+    // before the menu opened would otherwise keep moving the character in the
+    // background. Gating here is the single choke point for all held input.
+    if (g_pApp->IsMenuActive())
+    {
+        // Zero the stored analog-stick value. Unlike keyboard state (polled fresh
+        // each frame), the gamepad axis is only updated by events — which are
+        // dropped while the menu is open. Without this, releasing/centering the
+        // stick during the pause is never registered, so the stale value would
+        // keep moving the character the moment the menu closes.
+        m_GamepadMoveX = 0.0f;
+        m_GamepadMoveY = 0.0f;
+        return;
+    }
+
     int count;
     SDL_PumpEvents();
     m_pKeyStates = SDL_GetKeyboardState(&count);

--- a/OpenClaw/Engine/UserInterface/HumanView.cpp
+++ b/OpenClaw/Engine/UserInterface/HumanView.cpp
@@ -379,8 +379,11 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
 
         case AppEventType::GamepadButtonUp:
         {
-            bool ingameMenuVisible = m_pIngameMenu && m_pIngameMenu->VIsVisible();
-            if (!ingameMenuVisible && m_pGamepadHandler) {
+            // Always forward button-up (even while the menu is open) so a d-pad
+            // direction released during the pause gets cleared — otherwise the
+            // held-direction state sticks and the player moves on unpause. Mirrors
+            // the keyboard key-up handling.
+            if (m_pGamepadHandler) {
                 return m_pGamepadHandler->VOnGamepadButtonUp(evt.gamepadButton.button);
             }
             return false;

--- a/OpenClaw/Engine/UserInterface/HumanView.cpp
+++ b/OpenClaw/Engine/UserInterface/HumanView.cpp
@@ -211,16 +211,24 @@ bool HumanView::VOnEvent(SDL_Event& evt)
         {
             if (evt.key.repeat == 0)
             {
+                bool ingameMenuVisible = m_pIngameMenu && m_pIngameMenu->VIsVisible();
+
                 if (SDL_GetScancodeFromKey(evt.key.keysym.sym) == SDL_SCANCODE_ESCAPE &&
                     g_pApp->GetGameLogic()->GetGameState() == GameState_IngameRunning &&
                     m_pIngameMenu &&
-                    !m_pIngameMenu->VIsVisible())
+                    !ingameMenuVisible)
                 {
                     m_pIngameMenu->VSetVisible(true);
                     return true;
                 }
 
-                return m_pKeyboardHandler->VOnKeyDown(evt.key.keysym.sym);
+                // Don't feed new gameplay input to the player while the ingame menu
+                // is open, otherwise the character keeps responding in the background.
+                if (!ingameMenuVisible)
+                {
+                    return m_pKeyboardHandler->VOnKeyDown(evt.key.keysym.sym);
+                }
+                return false;
             }
             break;
         }
@@ -228,6 +236,8 @@ bool HumanView::VOnEvent(SDL_Event& evt)
         {
             if (evt.key.repeat == 0)
             {
+                // Always forward key-up so a key held when the menu opened gets
+                // cleared on release — prevents the player bolting when the menu closes.
                 return m_pKeyboardHandler->VOnKeyUp(evt.key.keysym.sym);
             }
             break;


### PR DESCRIPTION
## Summary

- Block player input while the ingame quick menu is open. Player movement previously leaked through to the game world when paused.
- Gate ActorController::OnUpdate on IsMenuActive() so held keys and analog-stick input stop driving the character while a menu is open, and skip forwarding new key-down events to the controller in HumanView.
- Always forward key-up and gamepad button-up (even while paused) so a key or d-pad direction released during the pause is cleared, and zero the stored analog value while paused, preventing the character from moving on unpause.
