### PR TITLE
feat: volume slider input via keys, gamepad, and mouse

### DIFF
--- a/Build_Release/ASSETS/INGAME_MENU.XML
+++ b/Build_Release/ASSETS/INGAME_MENU.XML
@@ -653,7 +653,7 @@
                     <Key>LeftArrow</Key>
                     <Event>
                         <Type>ModifyVolume</Type>
-                        <DeltaVolume>-2</DeltaVolume>
+                        <DeltaVolume>-10</DeltaVolume>
                         <IsMusic>true</IsMusic>
                     </Event>
                 </KeyEvent>
@@ -661,7 +661,7 @@
                 <Key>RightArrow</Key>
                     <Event>
                         <Type>ModifyVolume</Type>
-                        <DeltaVolume>2</DeltaVolume>
+                        <DeltaVolume>10</DeltaVolume>
                         <IsMusic>true</IsMusic>
                     </Event>
                 </KeyEvent>

--- a/Build_Release/ASSETS/MENU.xml
+++ b/Build_Release/ASSETS/MENU.xml
@@ -2732,7 +2732,7 @@
                     <Key>LeftArrow</Key>
                     <Event>
                         <Type>ModifyVolume</Type>
-                        <DeltaVolume>-2</DeltaVolume>
+                        <DeltaVolume>-10</DeltaVolume>
                         <IsMusic>true</IsMusic>
                     </Event>
                     <Event>
@@ -2747,7 +2747,7 @@
                 <Key>RightArrow</Key>
                     <Event>
                         <Type>ModifyVolume</Type>
-                        <DeltaVolume>2</DeltaVolume>
+                        <DeltaVolume>10</DeltaVolume>
                         <IsMusic>true</IsMusic>
                     </Event>
                     <Event>

--- a/OpenClaw/Engine/UserInterface/UserInterface.cpp
+++ b/OpenClaw/Engine/UserInterface/UserInterface.cpp
@@ -1082,6 +1082,16 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
         SDL_GetMouseState(&mouseX, &mouseY);
 #endif
 
+        // While a slider is grabbed, drag updates its volume from the pointer X.
+        if (shared_ptr<ScreenElementMenuItem> pSlider = m_pDraggedSlider.lock())
+        {
+            int menuX = (int)((mouseX - g_MenuOffset.x) / g_MenuScale.x);
+            pSlider->SetVolumeFromPointerX(menuX);
+            m_LastMouseX = mouseX;
+            m_LastMouseY = mouseY;
+            return true;
+        }
+
         if (mouseX != m_LastMouseX || mouseY != m_LastMouseY)
         {
             m_LastMouseX = mouseX;
@@ -1134,6 +1144,28 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
             clickPoint.w = 1;
             clickPoint.h = 1;
 
+            // Volume sliders first: a click on the track sets the volume and starts
+            // a drag. Checked before the button loop so a track click doesn't fall
+            // through to the on/off button sitting behind the slider.
+            for (shared_ptr<ScreenElementMenuItem> pMenuItem : m_MenuItems)
+            {
+                if (!pMenuItem->IsSlider() || !pMenuItem->VIsVisible())
+                {
+                    continue;
+                }
+                SDL_Rect trackRect = pMenuItem->GetSliderTrackRect();
+                if (SDL_HasIntersection(&clickPoint, &trackRect))
+                {
+                    pMenuItem->SetVolumeFromPointerX(clickPoint.x);
+                    m_pDraggedSlider = pMenuItem;
+#ifdef __EMSCRIPTEN__
+                    if (g_pApp->WasLastInputTouch())
+                        HapticFeedback::Trigger(HapticPreset::Light);
+#endif
+                    return true;
+                }
+            }
+
             for (shared_ptr<ScreenElementMenuItem> pMenuItem : m_MenuItems)
             {
                 SDL_Rect itemRect = pMenuItem->GetMenuItemRect();
@@ -1152,6 +1184,15 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
                     }
                 }
             }
+        }
+    }
+    else if (evt.type == SDL_MOUSEBUTTONUP)
+    {
+        // End any slider drag.
+        if (!m_pDraggedSlider.expired())
+        {
+            m_pDraggedSlider.reset();
+            return true;
         }
     }
 
@@ -1527,6 +1568,60 @@ void ScreenElementMenuItem::VOnUpdate(uint32 msDiff)
         // Now both sliders use DeltaVolume: 10, so they have the same step size
         m_Position.SetX(m_DefaultPosition.x + (musicVolume * 2));
     }
+}
+
+// Volume 0-100 maps to knob X in [m_DefaultPosition.x, m_DefaultPosition.x + 200]
+// (see VOnUpdate). SLIDER_TRACK_PIXELS is that 200px span.
+static const int SLIDER_TRACK_PIXELS = 200;
+
+SDL_Rect ScreenElementMenuItem::GetSliderTrackRect()
+{
+    int knobW, knobH;
+    SDL_QueryTexture(m_Images[m_State]->GetTexture(), NULL, NULL, &knobW, &knobH);
+
+    // Track spans the full volume range plus the knob width, with a little vertical
+    // padding around the knob so it's comfortable to grab with a pointer.
+    const int vPad = knobH / 2;
+    SDL_Rect track;
+    track.x = (int)m_DefaultPosition.x;
+    track.y = (int)m_DefaultPosition.y - vPad;
+    track.w = SLIDER_TRACK_PIXELS + knobW;
+    track.h = knobH + vPad * 2;
+    return track;
+}
+
+void ScreenElementMenuItem::SetVolumeFromPointerX(int menuX)
+{
+    if (!IsSlider())
+    {
+        return;
+    }
+
+    // Ignore slider input when the corresponding channel is toggled off — a muted
+    // channel's volume can't be adjusted (matches the on/off button gating it).
+    bool isMusic = (m_Name == "MUSIC_KNOB");
+    if (isMusic ? !g_pApp->GetAudio()->IsMusicActive()
+                : !g_pApp->GetAudio()->IsSoundActive())
+    {
+        return;
+    }
+
+    // Center the knob under the pointer: subtract half the knob width so the
+    // grabbed point tracks the cursor rather than the knob's left edge.
+    int knobW, knobH;
+    SDL_QueryTexture(m_Images[m_State]->GetTexture(), NULL, NULL, &knobW, &knobH);
+    int relX = menuX - (int)m_DefaultPosition.x - knobW / 2;
+
+    int volume = (relX * 100) / SLIDER_TRACK_PIXELS;
+    volume = max(0, min(100, volume));
+
+    // Snap to the same 10% steps the keyboard/gamepad use (DeltaVolume: 10), so
+    // dragging lands on the same discrete values rather than arbitrary ones.
+    volume = ((volume + 5) / 10) * 10;
+    volume = max(0, min(100, volume));
+
+    IEventMgr::Get()->VQueueEvent(IEventDataPtr(
+        new EventData_Set_Volume(volume, false /*absolute*/, isMusic)));
 }
 
 void ScreenElementMenuItem::VOnRender(uint32 msDiff)

--- a/OpenClaw/Engine/UserInterface/UserInterface.cpp
+++ b/OpenClaw/Engine/UserInterface/UserInterface.cpp
@@ -1014,11 +1014,27 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
         }
         else if (keyCode == SDL_SCANCODE_LEFT)
         {
+            // Let the active item consume left/right first (e.g. volume sliders
+            // adjust their value). Only navigate columns if it doesn't.
+            if (shared_ptr<ScreenElementMenuItem> pActiveItem = GetActiveMenuItem())
+            {
+                if (pActiveItem->TryHandleKey(evt.key.keysym.sym))
+                {
+                    return true;
+                }
+            }
             MoveToMenuItemInColumn(activeMenuItemIdx, -1);
             return true;
         }
         else if (keyCode == SDL_SCANCODE_RIGHT)
         {
+            if (shared_ptr<ScreenElementMenuItem> pActiveItem = GetActiveMenuItem())
+            {
+                if (pActiveItem->TryHandleKey(evt.key.keysym.sym))
+                {
+                    return true;
+                }
+            }
             MoveToMenuItemInColumn(activeMenuItemIdx, 1);
             return true;
         }
@@ -1529,6 +1545,28 @@ void ScreenElementMenuItem::VOnRender(uint32 msDiff)
     renderRect.h = (int)(pCurrImage->GetHeight() * g_MenuScale.y);
 
     SDL_RenderCopy(m_pRenderer, pCurrImage->GetTexture(), NULL, &renderRect);
+}
+
+bool ScreenElementMenuItem::TryHandleKey(SDL_Keycode key)
+{
+    // Fire this item's per-key events (e.g. a slider's Left/Right -> ModifyVolume).
+    // Returns true if the item had events bound to the key and consumed it.
+    if (m_State != MenuItemState_Active)
+    {
+        return false;
+    }
+
+    auto findIt = m_KeyToEventMap.find(SDL_GetScancodeFromKey(key));
+    if (findIt == m_KeyToEventMap.end())
+    {
+        return false;
+    }
+
+    for (IEventDataPtr pEvent : findIt->second)
+    {
+        IEventMgr::Get()->VQueueEvent(pEvent);
+    }
+    return true;
 }
 
 bool ScreenElementMenuItem::VOnEvent(SDL_Event& evt)

--- a/OpenClaw/Engine/UserInterface/UserInterface.h
+++ b/OpenClaw/Engine/UserInterface/UserInterface.h
@@ -326,6 +326,7 @@ public:
     bool Focus();
     bool CanBeFocused();
     bool Press();
+    bool TryHandleKey(SDL_Keycode key);
     SDL_Rect GetMenuItemRect();
 
     void OnStateChanged(MenuItemState newState, MenuItemState oldState);

--- a/OpenClaw/Engine/UserInterface/UserInterface.h
+++ b/OpenClaw/Engine/UserInterface/UserInterface.h
@@ -242,6 +242,11 @@ private:
     // Last mouse position used to detect real movement vs SDL noise
     int m_LastMouseX;
     int m_LastMouseY;
+
+    // Volume-slider mouse/pen dragging. When a slider is grabbed, the pointer's X
+    // sets the volume directly (and keeps updating while dragged), instead of the
+    // click falling through to the on/off button underneath.
+    weak_ptr<ScreenElementMenuItem> m_pDraggedSlider;
 };
 
 enum MenuItemType
@@ -328,6 +333,14 @@ public:
     bool Press();
     bool TryHandleKey(SDL_Keycode key);
     SDL_Rect GetMenuItemRect();
+
+    // Volume-slider support (SOUND_KNOB / MUSIC_KNOB).
+    bool IsSlider() const { return m_Type == MenuItemType_Slider; }
+    // Clickable/draggable track area (wider than the knob sprite itself).
+    SDL_Rect GetSliderTrackRect();
+    // Map a pointer X (in menu-space) to a 0-100 volume and fire an absolute
+    // Set_Volume event for this slider. No-op if the item isn't a volume slider.
+    void SetVolumeFromPointerX(int menuX);
 
     void OnStateChanged(MenuItemState newState, MenuItemState oldState);
     void ReEvaluateStateCondition();


### PR DESCRIPTION
## Summary

- Make volume sliders respond to left/right. Menu left/right was hardcoded to navigate between items, so the sliders never fired their ModifyVolume events. The active item now consumes the key first, falling back to navigation otherwise. Works for keyboard and gamepad.
- Match the music slider step size to the sound slider (10% increments) in both the ingame and main menus.
- Add mouse/pen support: clicking or dragging a slider track sets the volume by pointer position instead of toggling the on/off button behind it. Ignores input when the channel is off and snaps to the same 10% steps as the keys.
