### PR TITLE
fix: make sound and music toggles independent

### DIFF
--- a/OpenClaw/Engine/Audio/Audio.cpp
+++ b/OpenClaw/Engine/Audio/Audio.cpp
@@ -344,10 +344,11 @@ void Audio::SetMusicActive(bool active)
     m_bMusicOn = active;
 
     if (m_audioSystem) {
+        // SetMusicEnabled mutes/unmutes via the gain node while leaving the music
+        // source alive. Do NOT StopMusic() on disable: that tears down the source
+        // and gain node, so re-enabling has nothing left to unmute and music never
+        // resumes (the bug where toggling music off then on again killed it).
         m_audioSystem->SetMusicEnabled(m_bMusicOn);
-        if (!m_bMusicOn) {
-            m_audioSystem->StopMusic();
-        }
     }
 }
 

--- a/OpenClaw/Engine/Audio/WASM/AudioWorkletSystem.cpp
+++ b/OpenClaw/Engine/Audio/WASM/AudioWorkletSystem.cpp
@@ -414,7 +414,10 @@ bool AudioWorkletSystem::PlaySoundWithPath(const std::string& originalPath, cons
                     window.activeSources = window.activeSources || new Map();
                     const isLooping = (loops === -1);
 
-                    if (isLooping || isMusic) {
+                    // Music (e.g. MENUBED) is tracked separately via window.musicSource
+                    // and must NOT go into activeSources, otherwise StopAllSounds()
+                    // (fired when SFX are toggled off) would also stop the music.
+                    if (isLooping && !isMusic) {
                         if (window.activeSources.has(originalPath)) {
                             try {
                                 window.activeSources.get(originalPath).stop();


### PR DESCRIPTION
## Summary

- Make the sound and music toggles independent of each other.
- Fix music dying permanently after toggling it off then on: SetMusicActive no longer tears down the music source, relying on the gain-based mute/unmute so re-enabling resumes playback.
- Fix toggling SFX off also stopping the music: menu music is no longer registered in the SFX source registry, so StopAllSounds (fired on sound-off) leaves the music playing.
