### PR TITLE
fix: make game over work correctly on all input devices

### DIFF
--- a/Build_Release/ASSETS/GAME_OVER_MENU.XML
+++ b/Build_Release/ASSETS/GAME_OVER_MENU.XML
@@ -29,7 +29,7 @@
          <MenuItem>
             <Name>MAIN_MENU_TEXT</Name>
             <Type>Text</Type>
-            <State>Active</State>
+            <State>Inactive</State>
             <InactiveImage>/GAME/IMAGES/MESSAGES/GAMEOVER4.PID</InactiveImage>
             <ActiveImage>/GAME/IMAGES/MESSAGES/GAMEOVER4.PID</ActiveImage>
             <Position x="177" y="193" />

--- a/OpenClaw/ClawGameLogic.cpp
+++ b/OpenClaw/ClawGameLogic.cpp
@@ -438,6 +438,14 @@ void ClawGameLogic::ClawDiedDelegate(IEventDataPtr pEventData)
     IEventMgr* pEventMgr = IEventMgr::Get();
     pEventMgr->VTriggerEvent(IEventDataPtr(new EventData_Modify_Player_Stat(pCastEventData->GetActorId(), PlayerStat_Lives, -1, true)));
 
+    // On the final death (no lives left) don't revive/respawn Claw — the game-over
+    // screen takes over. Claw is held in his death pose by ClawControllableComponent
+    // (it skips the physics/animation restore and pauses the death animation).
+    if (pCastEventData->GetRemainingLives() < 0)
+    {
+        return;
+    }
+
     pEventMgr->VQueueEvent(IEventDataPtr(new EventData_Modify_Player_Stat(pCastEventData->GetActorId(), PlayerStat_Health, 1000, true)));
 
     // Clamp Claw to the floor when spawning him

--- a/OpenClaw/Engine/Actor/Components/ControllableComponent.cpp
+++ b/OpenClaw/Engine/Actor/Components/ControllableComponent.cpp
@@ -1000,15 +1000,44 @@ void ClawControllableComponent::VOnAnimationLooped(Animation* pAnimation)
         shared_ptr<LifeComponent> pClawLifeComponent = MakeStrongPtr(m_pOwner->GetComponent<LifeComponent>());
         assert(pClawLifeComponent != nullptr);
 
+        int remainingLives = pClawLifeComponent->GetLives() - 1;
+
         shared_ptr<EventData_Claw_Died> pEvent(new EventData_Claw_Died(
-            m_pOwner->GetGUID(), 
-            m_pPositionComponent->GetPosition(), 
-            pClawLifeComponent->GetLives() - 1));
+            m_pOwner->GetGUID(),
+            m_pPositionComponent->GetPosition(),
+            remainingLives));
         IEventMgr::Get()->VTriggerEvent(pEvent);
 
-        SetCurrentPhysicsState();
-        m_pPhysicsComponent->RestoreGravityScale();
-        m_pRenderComponent->SetVisible(true);
+        // On the final death (no lives left) there is no respawn — freeze Claw in
+        // his lying-down death pose instead of restoring physics/gravity/visibility,
+        // which would animate him back up to standing. The spikedeath animation is
+        // [0: falling, 1: lying down, 2: vanish]; pin to the lying-down frame (1),
+        // not the last frame (which is the disappear frame for the normal respawn).
+        if (remainingLives < 0)
+        {
+            // Freeze on the lying-down death frame. The spikedeath animation is
+            // [0: falling, 1: lying down, 2: vanish]; pin frame 1, not the last
+            // frame (the disappear frame used for the normal respawn).
+            uint32 frameCount = pAnimation->GetAnimFramesSize();
+            uint32 restFrame = frameCount >= 2 ? 1 : 0;
+            pAnimation->SetAnimationFrame(restFrame);
+            pAnimation->Pause();
+            // SetAnimationFrame only updates the animation's current-frame data; the
+            // rendered sprite is fed separately via the render component. Push the
+            // pinned frame's image directly so the lying-down sprite actually shows
+            // (otherwise the last image pushed — the loop-wrap frame — keeps drawing).
+            AnimationFrame* pRestFrame = pAnimation->GetCurrentAnimationFrame();
+            if (m_pRenderComponent && pRestFrame)
+            {
+                m_pRenderComponent->SetImage(pRestFrame->imageName);
+            }
+        }
+        else
+        {
+            SetCurrentPhysicsState();
+            m_pPhysicsComponent->RestoreGravityScale();
+            m_pRenderComponent->SetVisible(true);
+        }
     }
     else if (animName == "damage1" ||
              animName == "damage2")

--- a/OpenClaw/Engine/UserInterface/HumanView.cpp
+++ b/OpenClaw/Engine/UserInterface/HumanView.cpp
@@ -277,7 +277,8 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
         case AppEventType::GamepadButtonDown:
         {
             GameState gameState = g_pApp->GetGameLogic()->GetGameState();
-            bool ingameMenuVisible = m_pIngameMenu && m_pIngameMenu->VIsVisible();
+            // Any active menu — quick menu, main menu, OR the game-over screen.
+            bool menuActive = g_pApp->IsMenuActive();
 
 
             // Handle Start button for pause menu (like ESC key)
@@ -290,8 +291,8 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
                 return true;
             }
 
-            // Handle gamepad input for menus (main menu or ingame menu visible)
-            bool inMenu = (gameState == GameState_Menu || ingameMenuVisible);
+            // Handle gamepad input for menus (main menu, quick menu, or game-over)
+            bool inMenu = (gameState == GameState_Menu || menuActive);
 
             if (inMenu)
             {
@@ -369,8 +370,8 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
                 }
             }
 
-            // Forward to gamepad handler for in-game controls (only if menu not visible)
-            if (!ingameMenuVisible && m_pGamepadHandler) {
+            // Forward to gamepad handler for in-game controls (only if no menu active)
+            if (!menuActive && m_pGamepadHandler) {
                 return m_pGamepadHandler->VOnGamepadButtonDown(
                     evt.gamepadButton.button, evt.gamepadButton.value);
             }
@@ -393,8 +394,8 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
         {
             // Handle analog stick for menu navigation
             GameState gameState = g_pApp->GetGameLogic()->GetGameState();
-            bool ingameMenuVisible = m_pIngameMenu && m_pIngameMenu->VIsVisible();
-            bool inMenu = (gameState == GameState_Menu || ingameMenuVisible);
+            bool menuActive = g_pApp->IsMenuActive();
+            bool inMenu = (gameState == GameState_Menu || menuActive);
 
             if (inMenu && evt.gamepadAxis.axis == GamepadAxis::LeftStickY)
             {
@@ -439,8 +440,8 @@ bool HumanView::VOnGamepadEvent(const AppEvent& evt)
                 return true;
             }
 
-            // Forward to gamepad handler for in-game controls (only if menu not visible)
-            if (!ingameMenuVisible && m_pGamepadHandler) {
+            // Forward to gamepad handler for in-game controls (only if no menu active)
+            if (!menuActive && m_pGamepadHandler) {
                 return m_pGamepadHandler->VOnGamepadAxis(
                     evt.gamepadAxis.axis, evt.gamepadAxis.value);
             }
@@ -1010,6 +1011,7 @@ void HumanView::EnterMenuDelegate(IEventDataPtr pEventData)
     m_pScene.reset(new ScreenElementScene(g_pApp->GetRenderer()));
     m_pHUD.reset();
     m_pIngameMenu.reset();
+    m_pGameOverMenu.reset();
     m_pCamera->SetParent(nullptr);
 
     g_pApp->GetAudio()->StopAllSounds();
@@ -1157,11 +1159,14 @@ void HumanView::ClawDiedDelegate(IEventDataPtr pEventData)
         TiXmlElement* pXmlGameOverMenuRoot = XmlResourceLoader::LoadAndReturnRootXmlElement("GAME_OVER_MENU.XML");
         assert(pXmlGameOverMenuRoot != NULL);
 
-        shared_ptr<ScreenElementMenu> pGameOverMenu(new ScreenElementMenu(g_pApp->GetRenderer()));
-        DO_AND_CHECK(pGameOverMenu->Initialize(pXmlGameOverMenuRoot));
+        // Track as a member so GetActiveMenu()/IsMenuActive() recognize the
+        // game-over screen — otherwise the touch overlay never switches to menu
+        // mode and touch users can't leave the game-over screen.
+        m_pGameOverMenu.reset(new ScreenElementMenu(g_pApp->GetRenderer()));
+        DO_AND_CHECK(m_pGameOverMenu->Initialize(pXmlGameOverMenuRoot));
 
-        m_ScreenElements.push_back(pGameOverMenu);
-        pGameOverMenu->VSetVisible(true);
+        m_ScreenElements.push_back(m_pGameOverMenu);
+        m_pGameOverMenu->VSetVisible(true);
 
         IEventMgr::Get()->VAbortAllEvents();
     }

--- a/OpenClaw/Engine/UserInterface/HumanView.h
+++ b/OpenClaw/Engine/UserInterface/HumanView.h
@@ -60,7 +60,7 @@ public:
 
     void SetCurrentLevelMusic(const std::string& music) { m_CurrentLevelMusic = music; }
 
-shared_ptr<ScreenElementMenu> GetActiveMenu() { return m_pMenu ? m_pMenu : m_pIngameMenu; }
+shared_ptr<ScreenElementMenu> GetActiveMenu() { return m_pMenu ? m_pMenu : (m_pGameOverMenu ? m_pGameOverMenu : m_pIngameMenu); }
 
 protected:
     virtual bool VLoadGameDelegate(TiXmlElement* pLevelXmlElem, LevelData* pLevelData) { VPushElement(m_pScene); return true; }
@@ -110,6 +110,7 @@ protected:
     shared_ptr<CameraNode> m_pCamera;
     shared_ptr<Console> m_pConsole;
     shared_ptr<ScreenElementMenu> m_pIngameMenu;
+    shared_ptr<ScreenElementMenu> m_pGameOverMenu;
 
     shared_ptr<IKeyboardHandler> m_pKeyboardHandler;
     shared_ptr<IPointerHandler> m_pPointerHandler;

--- a/OpenClaw/Engine/UserInterface/UserInterface.cpp
+++ b/OpenClaw/Engine/UserInterface/UserInterface.cpp
@@ -986,10 +986,10 @@ void ScreenElementMenuPage::VOnRender(uint32 msDiff)
 bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
 {
     int activeMenuItemIdx = GetActiveMenuItemIdx();
-    if (m_MenuItems.size() > 0)
-    {
-        assert(activeMenuItemIdx >= 0);
-    }
+    // A page may legitimately have no focusable item (e.g. the game-over screen,
+    // which is display text plus page-level KeyboardEvents). In that case skip
+    // item-focus navigation but still let page KeyboardEvents be handled below.
+    bool hasActiveItem = (activeMenuItemIdx >= 0);
 
     if (evt.type == SDL_KEYDOWN)
     {
@@ -1004,12 +1004,12 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
         SDL_Keycode keyCode = SDL_GetScancodeFromKey(evt.key.keysym.sym);
         if (keyCode == SDL_SCANCODE_DOWN)
         {
-            MoveToMenuItemIdx(activeMenuItemIdx, 1);
+            if (hasActiveItem) MoveToMenuItemIdx(activeMenuItemIdx, 1);
             return true;
         }
         else if (keyCode == SDL_SCANCODE_UP)
         {
-            MoveToMenuItemIdx(activeMenuItemIdx, -1);
+            if (hasActiveItem) MoveToMenuItemIdx(activeMenuItemIdx, -1);
             return true;
         }
         else if (keyCode == SDL_SCANCODE_LEFT)
@@ -1023,7 +1023,7 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
                     return true;
                 }
             }
-            MoveToMenuItemInColumn(activeMenuItemIdx, -1);
+            if (hasActiveItem) MoveToMenuItemInColumn(activeMenuItemIdx, -1);
             return true;
         }
         else if (keyCode == SDL_SCANCODE_RIGHT)
@@ -1035,7 +1035,7 @@ bool ScreenElementMenuPage::VOnEvent(SDL_Event& evt)
                     return true;
                 }
             }
-            MoveToMenuItemInColumn(activeMenuItemIdx, 1);
+            if (hasActiveItem) MoveToMenuItemInColumn(activeMenuItemIdx, 1);
             return true;
         }
         else if (m_KeyToEventMap.find(keyCode) != m_KeyToEventMap.end())
@@ -1360,7 +1360,12 @@ bool ScreenElementMenuPage::MoveToMenuItemIdx(int oldIdx, int idxIncrement, bool
 
     while (true)
     {
-        assert(tryCount <= (int)m_MenuItems.size() && "Could not find any button to switch focus to");
+        // No focusable item on this page (e.g. the game-over screen, which only
+        // has display text). Bail gracefully instead of asserting/crashing.
+        if (tryCount > (int)m_MenuItems.size())
+        {
+            return false;
+        }
 
         // At first button and we pressed "up" -> move to last button
         if (buttonIdx < 0 && idxIncrement < 0)


### PR DESCRIPTION
## Summary

- Fix crashes when navigating the game-over screen: it has no focusable menu item, which triggered assertions in the menu navigation code. Navigation now bails gracefully on a page with no active item.
- Make the game-over screen purely informational (no spinning coins, no up/down navigation), matching the original game.
- Block gameplay input on the game-over screen across all devices: gamepad guards now use IsMenuActive() so Claw can no longer be controlled there, while confirm buttons still return to the main menu.
- Let touch users leave the game-over screen: the dynamically-created game-over menu is now tracked so the touch overlay recognizes it and shows its buttons.
- Keep Claw in his death pose instead of standing back up behind the text: on the final death he is no longer revived, and his death animation is pinned to the lying-down frame.

Closes #39
