### PR TITLE
chore: remove vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "outputDirectory": "Build_Release",
-  "rewrites": [
-    {
-      "source": "/",
-      "destination": "/openclaw.html"
-    }
-  ]
-}


### PR DESCRIPTION
Remove Vercel configuration. The project builds locally and deploys to gh-pages manually. No need for Vercel integration.