### PR TITLE
chore: gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,10 @@ Build_Release/openclaw.html
 !Build_Release/resource-*.js
 !Build_Release/graphics-bridge.js
 !Build_Release/texture-bridge.js
-!Build_Release/keyboard-capture.js!Build_Release/save-storage.js!Build_Release/gamepad-bridge.js!Build_Release/game-init.js
+!Build_Release/keyboard-capture.js
+!Build_Release/save-storage.js
+!Build_Release/gamepad-bridge.js
+!Build_Release/game-init.js
 
 # Test and demo files (development only)
 Build_Release/test-*.html
@@ -100,12 +103,6 @@ Release/
 # Local Claude Code settings
 CLAUDE.local.md
 
-# Caddy web server binary (install separately: https://caddyserver.com/docs/install)
-caddy
-caddy.exe
-
-# Developer-only documentation (not for players)
-docs/HTTP3_MIGRATION.md
 # Node dependencies and Vite build output
 node_modules/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ caddy.exe
 
 # Developer-only documentation (not for players)
 docs/HTTP3_MIGRATION.md
+# Node dependencies and Vite build output
+node_modules/
+dist/


### PR DESCRIPTION
## Summary

- Add `node_modules/` and `dist/` — the Vite integration (#64) added `package.json`/`vite.config.js` but never ignored them; the folders stay invisible until someone runs `yarn install` in a worktree
- Remove `caddy` / `caddy.exe` — Caddy was replaced by the Vite dev server (`caddy.exe` was also redundant with the existing `*.exe` rule)
- Remove `docs/HTTP3_MIGRATION.md` — the file no longer exists and the HTTP/3 migration was abandoned in favor of Vite
- Fix a malformed negation line where four `!Build_Release/*.js` patterns were concatenated without newlines, so only the first was taking effect