### PR TITLE
fix: remove excessive console logging from touch controls

### DIFF
--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -497,7 +497,6 @@
         var result = Module._IsMenuVisibleJS() === 1;
         var gameState = getGameState();
         var scoreScreenVisible = (typeof Module._IsScoreScreenVisibleJS === "function") ? (Module._IsScoreScreenVisibleJS() === 1) : "N/A";
-        console.log("[touch-controls] isMenuVisible=" + result + ", gameState=" + gameState + ", scoreScreenVisible=" + scoreScreenVisible);
         return result;
       } catch (e) {
         console.error("[touch-controls] isMenuVisibleJS error:", e);


### PR DESCRIPTION
Removes console.log and console.error statements in isMenuVisible() that were firing on every frame, causing memory consumption growth and console spam.

These logs were debug output left from the score screen logging feature and are no longer needed for production. The console.error in the catch block is retained since it only fires if exceptions actually occur.

- Removed unconditional console.log that fired every frame
- Kept console.error for actual error cases