### PR TITLE
chore: add gh-pages staging environment with per-deployment PWA isolation

### DIFF
--- a/Build_Release/env-marker.js
+++ b/Build_Release/env-marker.js
@@ -1,0 +1,23 @@
+// Environment marker: makes non-production deployments unmistakable.
+// Production (served at the gh-pages root) shows nothing; any sub-path
+// deployment (staging, previews) logs its env and paints a small,
+// click-through corner badge so it can never be confused with prod.
+(function () {
+  var m = location.pathname.match(/\/staging\//);
+  var env = m ? 'staging' : 'production';
+  console.info('[env] OpenClaw environment: ' + env + ' (' + location.pathname + ')');
+  if (env === 'production') return;
+  window.addEventListener('load', function () {
+    var b = document.createElement('div');
+    b.textContent = 'STAGING';
+    b.setAttribute('aria-hidden', 'true');
+    b.style.cssText =
+      'position:fixed;top:0;right:0;z-index:2147483647;pointer-events:none;' +
+      'font:700 11px/1 system-ui,sans-serif;letter-spacing:.08em;color:#fff;' +
+      'background:#b8860b;padding:3px 7px;border-bottom-left-radius:5px;' +
+      'opacity:.85;text-shadow:0 1px 1px rgba(0,0,0,.5);' +
+      'padding-top:calc(3px + env(safe-area-inset-top));' +
+      'padding-right:calc(7px + env(safe-area-inset-right));';
+    document.body.appendChild(b);
+  });
+})();

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -1540,111 +1540,12 @@
       })();
     </script>
 
-    <!-- Service Worker: installability + offline shell, with self-heal safety
-         net so a bad deploy can never permanently strand a client (important
-         on mobile, where clearing a stuck SW by hand is painful). -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        (function () {
-          // --- Remote kill-switch -------------------------------------------
-          // sw-control.json carries an "unregister" id. When that id changes,
-          // every client unregisters its SW + clears caches exactly once (we
-          // remember the last-handled id), then reloads clean. Page-side on
-          // purpose: it works even if the installed SW is broken. Fetched
-          // network-fresh (no-store) and bypassed by the SW.
-          function checkKillSwitch() {
-            return fetch('./sw-control.json', { cache: 'no-store' })
-              .then(function (r) { return r.ok ? r.json() : null; })
-              .then(function (ctl) {
-                if (!ctl) return false;
-                var id = String(ctl.unregister || '');
-                if (!id) return false;
-                var seen = localStorage.getItem('sw_unregister_id');
-                if (id === seen) return false; // already handled this signal
-                localStorage.setItem('sw_unregister_id', id);
-                console.warn('[SW] Kill-switch tripped (' + id + ') — clearing.');
-                // Scope the teardown to THIS environment. On a shared origin,
-                // getRegistrations()/caches.keys() see sibling deployments too;
-                // an unscoped clear would unregister production's SW and delete
-                // its caches when only staging's switch was flipped. We match
-                // our own scope path (the page's directory) for registrations
-                // and the sw.js cache-name convention ("openclaw::<scope>::")
-                // for caches.
-                var scopeDir = location.pathname.replace(/[^/]*$/, '');
-                var cachePrefix = 'openclaw::' + scopeDir + '::';
-                return navigator.serviceWorker.getRegistrations()
-                  .then(function (regs) {
-                    return Promise.all(regs
-                      .filter(function (r) {
-                        try { return new URL(r.scope).pathname === scopeDir; }
-                        catch (e) { return false; }
-                      })
-                      .map(function (r) { return r.unregister(); }));
-                  })
-                  .then(function () {
-                    return (self.caches ? caches.keys() : Promise.resolve([]));
-                  })
-                  .then(function (keys) {
-                    return Promise.all(keys
-                      .filter(function (k) { return k.indexOf(cachePrefix) === 0; })
-                      .map(function (k) { return caches.delete(k); }));
-                  })
-                  .then(function () { location.reload(); return true; });
-              })
-              .catch(function () { return false; });
-          }
-
-          // --- Auto-reload when a new SW takes control ----------------------
-          // Guarded so it fires at most once (no reload loop).
-          var refreshing = false;
-          navigator.serviceWorker.addEventListener('controllerchange', function () {
-            if (refreshing) return;
-            refreshing = true;
-            location.reload();
-          });
-
-          window.addEventListener('load', function () {
-            checkKillSwitch().then(function (tripped) {
-              if (tripped) return; // reloading; skip registration this pass
-              navigator.serviceWorker
-                .register('./sw.js', { scope: './' })
-                .then(function (reg) {
-                  // Periodic update check (once per day) + on focus.
-                  setInterval(function () { reg.update(); }, 24 * 60 * 60 * 1000);
-                })
-                .catch(function (err) {
-                  console.warn('[SW] Registration failed:', err);
-                });
-            });
-          });
-        })();
-      }
-    </script>
-
-    <!-- Environment marker: makes non-production deployments unmistakable.
-         Production (served at the gh-pages root) shows nothing; any sub-path
-         deployment (staging, previews) logs its env and paints a small,
-         click-through corner badge so it can never be confused with prod. -->
-    <script>
-      (function () {
-        var m = location.pathname.match(/\/staging\//);
-        var env = m ? 'staging' : 'production';
-        console.info('[env] OpenClaw environment: ' + env + ' (' + location.pathname + ')');
-        if (env === 'production') return;
-        window.addEventListener('load', function () {
-          var b = document.createElement('div');
-          b.textContent = 'STAGING';
-          b.setAttribute('aria-hidden', 'true');
-          b.style.cssText =
-            'position:fixed;top:0;right:0;z-index:2147483647;pointer-events:none;' +
-            'font:700 11px/1 system-ui,sans-serif;letter-spacing:.08em;color:#fff;' +
-            'background:#b8860b;padding:3px 7px;border-bottom-left-radius:5px;' +
-            'opacity:.85;text-shadow:0 1px 1px rgba(0,0,0,.5);' +
-            'padding-top:calc(3px + env(safe-area-inset-top));' +
-            'padding-right:calc(7px + env(safe-area-inset-right));';
-          document.body.appendChild(b);
-        });
-      })();
-    </script>
+    <!-- Service Worker registration + self-heal, and the non-production env
+         marker. Both are defer-safe (they act on window 'load' or at end of
+         parse), so external + defer is fine. The localStorage-isolation shim
+         stays INLINE in <head> because it must patch Storage.prototype before
+         any other script (incl. the save glue baked into openclaw.js) runs. -->
+    <script src="sw-register.js" defer></script>
+    <script src="env-marker.js" defer></script>
   </body>
 </html>

--- a/Build_Release/openclaw.html
+++ b/Build_Release/openclaw.html
@@ -3,6 +3,43 @@
   <head>
     <meta charset="UTF-8" />
 
+    <!-- Per-environment localStorage isolation. GitHub Pages serves every
+         deployment from ONE origin, and localStorage is origin-scoped, so
+         production (/WASM-OpenClaw/) and staging (/WASM-OpenClaw/staging/)
+         would otherwise share one key space: game saves, install-onboarding
+         flag, touch-mode, and the SW kill-switch id would all collide.
+         We namespace keys by scope. PRODUCTION KEEPS BARE KEYS so existing
+         users' saved games are preserved untouched; only sub-path
+         deployments (staging, previews) get a prefix. This runs before any
+         other script, so it also transparently covers the save-data glue
+         baked into openclaw.js (from SaveBridge.cpp) which we cannot edit
+         without a C++ rebuild. IndexedDB (CLAW.REZ + assets) is intentionally
+         NOT namespaced — it stays shared across environments. -->
+    <script>
+      (function () {
+        var path = location.pathname;
+        var m = path.match(/\/staging\//);
+        // Only sub-path environments get a prefix; production stays bare.
+        var PREFIX = m ? "staging:" : "";
+        if (!PREFIX) return; // production: no-op, native localStorage
+        try {
+          var proto = Object.getPrototypeOf(window.localStorage);
+          var raw = {
+            get: proto.getItem,
+            set: proto.setItem,
+            remove: proto.removeItem,
+          };
+          var wrap = function (k) { return PREFIX + k; };
+          proto.getItem = function (k) { return raw.get.call(this, wrap(k)); };
+          proto.setItem = function (k, v) { return raw.set.call(this, wrap(k), v); };
+          proto.removeItem = function (k) { return raw.remove.call(this, wrap(k)); };
+          console.info("[env] localStorage namespaced with prefix \"" + PREFIX + "\"");
+        } catch (e) {
+          console.warn("[env] Could not namespace localStorage:", e);
+        }
+      })();
+    </script>
+
     <title>OpenClaw</title>
     <meta
       name="description"
@@ -1526,15 +1563,31 @@
                 if (id === seen) return false; // already handled this signal
                 localStorage.setItem('sw_unregister_id', id);
                 console.warn('[SW] Kill-switch tripped (' + id + ') — clearing.');
+                // Scope the teardown to THIS environment. On a shared origin,
+                // getRegistrations()/caches.keys() see sibling deployments too;
+                // an unscoped clear would unregister production's SW and delete
+                // its caches when only staging's switch was flipped. We match
+                // our own scope path (the page's directory) for registrations
+                // and the sw.js cache-name convention ("openclaw::<scope>::")
+                // for caches.
+                var scopeDir = location.pathname.replace(/[^/]*$/, '');
+                var cachePrefix = 'openclaw::' + scopeDir + '::';
                 return navigator.serviceWorker.getRegistrations()
                   .then(function (regs) {
-                    return Promise.all(regs.map(function (r) { return r.unregister(); }));
+                    return Promise.all(regs
+                      .filter(function (r) {
+                        try { return new URL(r.scope).pathname === scopeDir; }
+                        catch (e) { return false; }
+                      })
+                      .map(function (r) { return r.unregister(); }));
                   })
                   .then(function () {
                     return (self.caches ? caches.keys() : Promise.resolve([]));
                   })
                   .then(function (keys) {
-                    return Promise.all(keys.map(function (k) { return caches.delete(k); }));
+                    return Promise.all(keys
+                      .filter(function (k) { return k.indexOf(cachePrefix) === 0; })
+                      .map(function (k) { return caches.delete(k); }));
                   })
                   .then(function () { location.reload(); return true; });
               })
@@ -1566,6 +1619,32 @@
           });
         })();
       }
+    </script>
+
+    <!-- Environment marker: makes non-production deployments unmistakable.
+         Production (served at the gh-pages root) shows nothing; any sub-path
+         deployment (staging, previews) logs its env and paints a small,
+         click-through corner badge so it can never be confused with prod. -->
+    <script>
+      (function () {
+        var m = location.pathname.match(/\/staging\//);
+        var env = m ? 'staging' : 'production';
+        console.info('[env] OpenClaw environment: ' + env + ' (' + location.pathname + ')');
+        if (env === 'production') return;
+        window.addEventListener('load', function () {
+          var b = document.createElement('div');
+          b.textContent = 'STAGING';
+          b.setAttribute('aria-hidden', 'true');
+          b.style.cssText =
+            'position:fixed;top:0;right:0;z-index:2147483647;pointer-events:none;' +
+            'font:700 11px/1 system-ui,sans-serif;letter-spacing:.08em;color:#fff;' +
+            'background:#b8860b;padding:3px 7px;border-bottom-left-radius:5px;' +
+            'opacity:.85;text-shadow:0 1px 1px rgba(0,0,0,.5);' +
+            'padding-top:calc(3px + env(safe-area-inset-top));' +
+            'padding-right:calc(7px + env(safe-area-inset-right));';
+          document.body.appendChild(b);
+        });
+      })();
     </script>
   </body>
 </html>

--- a/Build_Release/sw-register.js
+++ b/Build_Release/sw-register.js
@@ -1,0 +1,77 @@
+// Service Worker registration: installability + offline shell, with a
+// self-heal safety net so a bad deploy can never permanently strand a client
+// (important on mobile, where clearing a stuck SW by hand is painful).
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+
+  // --- Remote kill-switch -----------------------------------------------
+  // sw-control.json carries an "unregister" id. When that id changes, every
+  // client unregisters its SW + clears caches exactly once (we remember the
+  // last-handled id), then reloads clean. Page-side on purpose: it works even
+  // if the installed SW is broken. Fetched network-fresh (no-store) and
+  // bypassed by the SW.
+  function checkKillSwitch() {
+    return fetch('./sw-control.json', { cache: 'no-store' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (ctl) {
+        if (!ctl) return false;
+        var id = String(ctl.unregister || '');
+        if (!id) return false;
+        var seen = localStorage.getItem('sw_unregister_id');
+        if (id === seen) return false; // already handled this signal
+        localStorage.setItem('sw_unregister_id', id);
+        console.warn('[SW] Kill-switch tripped (' + id + ') — clearing.');
+        // Scope the teardown to THIS environment. On a shared origin,
+        // getRegistrations()/caches.keys() see sibling deployments too; an
+        // unscoped clear would unregister production's SW and delete its
+        // caches when only staging's switch was flipped. We match our own
+        // scope path (the page's directory) for registrations and the sw.js
+        // cache-name convention ("openclaw::<scope>::") for caches.
+        var scopeDir = location.pathname.replace(/[^/]*$/, '');
+        var cachePrefix = 'openclaw::' + scopeDir + '::';
+        return navigator.serviceWorker.getRegistrations()
+          .then(function (regs) {
+            return Promise.all(regs
+              .filter(function (r) {
+                try { return new URL(r.scope).pathname === scopeDir; }
+                catch (e) { return false; }
+              })
+              .map(function (r) { return r.unregister(); }));
+          })
+          .then(function () {
+            return (self.caches ? caches.keys() : Promise.resolve([]));
+          })
+          .then(function (keys) {
+            return Promise.all(keys
+              .filter(function (k) { return k.indexOf(cachePrefix) === 0; })
+              .map(function (k) { return caches.delete(k); }));
+          })
+          .then(function () { location.reload(); return true; });
+      })
+      .catch(function () { return false; });
+  }
+
+  // --- Auto-reload when a new SW takes control --------------------------
+  // Guarded so it fires at most once (no reload loop).
+  var refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', function () {
+    if (refreshing) return;
+    refreshing = true;
+    location.reload();
+  });
+
+  window.addEventListener('load', function () {
+    checkKillSwitch().then(function (tripped) {
+      if (tripped) return; // reloading; skip registration this pass
+      navigator.serviceWorker
+        .register('./sw.js', { scope: './' })
+        .then(function (reg) {
+          // Periodic update check (once per day).
+          setInterval(function () { reg.update(); }, 24 * 60 * 60 * 1000);
+        })
+        .catch(function (err) {
+          console.warn('[SW] Registration failed:', err);
+        });
+    });
+  });
+})();

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -31,6 +31,8 @@ const SHELL_ASSETS = [
   "./save-storage.js",
   "./gamepad-bridge.js",
   "./keyboard-capture.js",
+  "./sw-register.js",
+  "./env-marker.js",
   "./site.webmanifest",
   "./android-chrome-192x192.png",
   "./android-chrome-512x512.png",

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -1,6 +1,22 @@
 // PWA shell cache — includes all app bootstrap assets
 // Vite will serve these with consistent, deterministic paths
-const CACHE_NAME = "openclaw-v3";
+
+// Self-scope the cache name to this SW's own directory so multiple
+// deployments sharing one origin (e.g. production at /WASM-OpenClaw/ and
+// staging at /WASM-OpenClaw/staging/) get DISTINCT caches. Without this they
+// share the origin's Cache Storage, and a version bump in one environment
+// would run activate -> caches.keys() -> delete the OTHER environment's cache.
+// registration.scope is the source of truth; fall back to the SW's own path.
+const CACHE_VERSION = "v3";
+const SCOPE_PATH = (function () {
+  try {
+    return new URL(self.registration.scope).pathname;
+  } catch (e) {
+    return self.location.pathname.replace(/[^/]*$/, ""); // strip "sw.js"
+  }
+})();
+const CACHE_PREFIX = "openclaw::" + SCOPE_PATH + "::";
+const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
 // Essential assets needed to boot the game
 // These are served by Vite and have stable, hashed filenames in production
@@ -40,7 +56,13 @@ self.addEventListener("install", (event) => {
   );
 });
 
-// On activate: remove old caches if CACHE_NAME changes
+// On activate: prune only THIS scope's stale caches. We must never delete a
+// sibling deployment's cache, so we only touch keys under our own CACHE_PREFIX
+// (plus the legacy pre-scoping "openclaw-*" names). Legacy caches are only
+// reclaimed by non-staging scopes: production created them before scoping
+// existed, and staging never ran the old scheme, so staging must leave them
+// for production to clean up.
+var IS_STAGING = /\/staging\//.test(SCOPE_PATH);
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches
@@ -48,7 +70,12 @@ self.addEventListener("activate", (event) => {
       .then((keys) =>
         Promise.all(
           keys
-            .filter((k) => k !== CACHE_NAME)
+            .filter((k) => {
+              if (k === CACHE_NAME) return false; // keep current
+              var ours = k.indexOf(CACHE_PREFIX) === 0;
+              var legacy = /^openclaw-/.test(k) && !IS_STAGING;
+              return ours || legacy;
+            })
             .map((k) => {
               console.log("[SW] Deleting old cache:", k);
               return caches.delete(k);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Guidance for Claude Code when working in this repository.
 
+> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/WASM-OpenClaw`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/OpenClaw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/WASM-OpenClaw`.
+
 ## Overview
 
 OpenClaw WASM is a browser-based fork of Captain Claw (1997), focused on optimizing the WebAssembly build. The original archive (`CLAW.REZ`, ~113MB) is **not** bundled: the user uploads it once and it's stored compressed in IndexedDB. Startup is fast (~48MB download, 2-3s) because level assets lazy-load on demand.
@@ -117,8 +119,15 @@ Emscripten flags live in `CMakeLists.txt` (SDL2 + image/ttf/gfx/mixer, `ASYNCIFY
 ## Known Limitations
 
 - MIDI audio not supported on WASM (WAV/OGG fine).
-- Firefox: ALT opens the window menu (browser bug) — use fullscreen.
+- Firefox: ALT opens the window menu (browser bug); use fullscreen.
 - Death/teleport fade effects can have rendering quirks.
+
+**iOS / Apple:**
+
+- The browser Fullscreen API is unsupported on iOS (iPhone/iPad, and iPadOS Safari that reports as `MacIntel` with touch). Toggling it crashes the game, so the fullscreen menu controls are hidden on iOS (`UserInterface.cpp` `FullscreenOn`/`FullscreenOff`). True fullscreen on iOS is only available by installing the PWA to the home screen (standalone display mode) — hence the install prompt is `recommended` on iOS Safari.
+- On desktop Safari (macOS), pressing Ctrl+Arrow while fullscreen can switch Spaces and leave the game stuck in fullscreen; recovery is via the OS, not the game.
+- iOS Safari reports stale viewport dimensions during an orientation change, so layout must re-measure after a short delay on `orientationchange` (handled in `openclaw.html`).
+- Web Audio / AudioWorklet and Keyboard Lock require a secure context on iOS too, so local IP testing over plain HTTP will not have audio or key capture.
 
 ## Docs & References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,39 +102,19 @@ The dev server starts on `http://localhost:5173/`
 
 ## Deployment (GitHub Pages)
 
-GitHub Actions is unavailable on this account (billing), so deploys are manual via the committed scripts in `scripts/`. Both environments live on the single `gh-pages` branch — **production at the root**, **staging under `/staging/`** — and neither script can clobber the other (`deploy-prod.sh` excludes `staging/` from its `--delete`; `deploy-staging.sh` writes only `/staging/`).
+Deploys are manual (no GitHub Actions — billing) via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
 
-- **Production:** <https://arthurboss.github.io/WASM-OpenClaw/>
-- **Staging:** <https://arthurboss.github.io/WASM-OpenClaw/staging/>
+- **Production:** <https://arthurboss.github.io/WASM-OpenClaw/> — `./scripts/deploy-prod.sh ["msg"]`
+- **Staging:** <https://arthurboss.github.io/WASM-OpenClaw/staging/> — `./scripts/deploy-staging.sh ["msg"]`
 
-```bash
-# Deploy current Build_Release/ to production (root)
-./scripts/deploy-prod.sh ["commit msg"]
+**Default workflow:** deploy every new branch to **staging first** (safe — never touches prod), test on a real device, then merge and run `deploy-prod.sh` to promote. Skip only for deploy-only/non-visual changes.
 
-# Deploy current Build_Release/ to staging (/staging/ only)
-./scripts/deploy-staging.sh ["commit msg"]
-```
+**Env isolation** (prod + staging share one origin, so storage is scoped deliberately):
 
-Both scripts verify the WASM artifact set is fresh (guarding the `ASM_CONSTS` boot crash from a stale/mismatched loader+wasm pair) and clean up their temp worktree on exit.
-
-### Default workflow: deploy every branch to staging
-
-**When working on a new branch, deploy it to staging by default** so it can be tested on a real device (especially mobile) before merging. Staging never touches production, so this is safe. The loop:
-
-1. Build on the VM; make changes in `Build_Release/`.
-2. `./scripts/deploy-staging.sh` → test at the staging URL.
-3. Once verified, merge the PR, then `./scripts/deploy-prod.sh` to promote to production.
-
-Skip staging only for deploy-only/non-visual changes, or when the change cannot be exercised in the browser.
-
-### Environment isolation
-
-Production and staging share one origin (`arthurboss.github.io`), so origin-scoped web storage is isolated deliberately:
-
-- **Service worker cache** is named per deployment scope (`openclaw::<scope>::<version>`), so a version bump in one environment cannot delete the other's cache. The kill-switch teardown is likewise scoped to its own environment.
-- **`localStorage`** is namespaced by scope: production keeps bare keys (preserving existing users' saves); `/staging/` gets a `staging:` prefix. This covers game saves, the install-onboarding flag, touch-mode, and the SW kill-switch id. Implemented as a `Storage.prototype` shim inlined in `<head>` (must run before the save glue baked into `openclaw.js`), so it stays inline while `sw-register.js`/`env-marker.js` are external.
-- **`IndexedDB`** (the uploaded `CLAW.REZ` and assets) is intentionally **shared**, so staging does not require re-uploading the game file.
-- A gold **STAGING** badge marks non-production builds so they can't be confused with prod.
+- **SW cache** named per scope (`openclaw::<scope>::<version>`) — a version bump in one env can't delete the other's cache; kill-switch teardown is scoped too.
+- **`localStorage`** namespaced by scope: prod keeps bare keys (preserves existing saves), `/staging/` gets a `staging:` prefix. Done via a `Storage.prototype` shim inlined in `<head>` — it **must** stay inline (runs before the save glue baked into `openclaw.js`), unlike `sw-register.js`/`env-marker.js` which are external.
+- **`IndexedDB`** (`CLAW.REZ` + assets) is intentionally **shared** — staging needs no re-upload.
+- Gold **STAGING** badge marks non-production builds.
 
 
 ## Code Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,108 +1,40 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code when working in this repository.
 
-> **Note:** Local environment settings and personal preferences are in `CLAUDE.local.md` (gitignored)
+## Overview
 
-## Project Overview
-
-OpenClaw WASM is a browser-based version of Captain Claw (1997), a classic platformer game. This is a WASM-only fork that focuses on optimizing the WebAssembly implementation for modern browsers. The game uses assets from the original game archive (CLAW.REZ) which users upload once and store in IndexedDB.
-
-**Key Features:**
-
-- Fast loading: Only 48MB download, 2-3 second startup
-- Lazy-loading architecture: Assets load on-demand as you play
-- One-time setup: Upload CLAW.REZ once, play forever
-- Full game: All 14 levels with original graphics and audio
+OpenClaw WASM is a browser-based fork of Captain Claw (1997), focused on optimizing the WebAssembly build. The original archive (`CLAW.REZ`, ~113MB) is **not** bundled: the user uploads it once and it's stored compressed in IndexedDB. Startup is fast (~48MB download, 2-3s) because level assets lazy-load on demand.
 
 ## Prerequisites
 
-### Required Files
+- **`CLAW.REZ`** — original game archive (~113MB, uploaded at runtime, not in repo).
+- **`ASSETS.ZIP`** — custom assets, auto-generated from `Build_Release/ASSETS/`.
+- Emscripten SDK (`emsdk/`, gitignored), CMake 4.10+, Node.js 18+ (Vite).
+- Browsers: Chrome 105+ / Firefox 121+ / Safari 16.4+ / Edge 105+.
 
-- `CLAW.REZ` - Original game archive (112MB, user uploads at runtime)
-- `ASSETS.ZIP` - Custom assets archive (auto-generated from `Build_Release/ASSETS/`)
-
-### Build Tools
-
-- Emscripten SDK (in `emsdk/` directory, gitignored)
-- CMake 4.10+
-- Node.js 18+ (for Vite dev server)
-- Python 3 (optional, for basic HTTP server as fallback)
-
-### Browser Requirements
-
-- Chrome 105+ / Firefox 121+ / Safari 16.4+ / Edge 105+
-- ~160MB free storage (for cached game files in IndexedDB)
-
-## Build Commands
-
-### Quick Build (Recommended)
+## Build
 
 ```bash
 source ./emsdk/emsdk_env.sh
-./build_wasm.sh
+./build_wasm.sh          # regenerate ASSETS.ZIP, configure, compile, patch SDL2 shaders, relink
+cd build && make -j$(nproc)   # C++-only incremental build
+rm -rf build && ./build_wasm.sh   # clean build
 ```
 
-**What it does:**
+> **SDL2 shader patch** (`patch_sdl2_shaders.sh`, run by `build_wasm.sh`) is required for WebGL: it disables `GL_OES_EGL_image_external` and swaps `samplerExternalOES` for `sampler2D`. A hand-rolled `cmake`/`make` build must run it after the first `make`, then clear `emsdk/upstream/emscripten/cache/build/sdl2` and rebuild.
 
-1. Regenerates ASSETS.ZIP from Build_Release/ASSETS/
-2. Configures CMake for Emscripten
-3. Compiles C++ to WebAssembly
-4. Patches SDL2 shaders for WebGL compatibility
-5. Rebuilds with patched shaders
-6. Shows build summary
-
-**Build time:** 5-10 minutes (first build), 1-2 minutes (incremental)
-
-### Manual Build (Advanced)
+## Running Locally
 
 ```bash
-# 1. Activate Emscripten environment
-source ./emsdk/emsdk_env.sh
-
-# 2. Configure with CMake
-mkdir build
-cd build
-emcmake cmake -DEmscripten=1 ..
-
-# 3. First build (downloads SDL2)
-make -j$(nproc)
-
-# 4. Patch SDL2 shaders for WebGL compatibility
-cd ..
-./patch_sdl2_shaders.sh
-
-# 5. Clear SDL2 cache and rebuild
-rm -rf ./emsdk/upstream/emscripten/cache/build/sdl2
-cd build
-make -j$(nproc)
+yarn dev                 # Vite at http://localhost:5173/
 ```
 
-**Important:** SDL2 shader patching is required to disable `GL_OES_EGL_image_external` and replace `samplerExternalOES` with `sampler2D` for WebGL compatibility.
-
-## Running the Game Locally
-
-### Option 1: Vite Dev Server (Recommended for Local Development)
-
-Vite provides hot reload and clean URLs:
-
-```bash
-yarn dev
-```
-
-The dev server starts on `http://localhost:5173/`
-
-**Benefits:**
-
-- Hot module reload for rapid iteration
-- `localhost` is a secure context (Keyboard Lock API, Web Audio work correctly)
-- Root `/` rewrites to `/openclaw.html` automatically
-- No certificate warnings
-
+Vite gives hot reload and rewrites `/` → `/openclaw.html`. Serve over `localhost` (a **secure context**), which Keyboard Lock and Web Audio / AudioWorklet require; a plain-HTTP LAN IP breaks those APIs.
 
 ## Deployment (GitHub Pages)
 
-Deploys are manual (no GitHub Actions — billing) via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
+Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
 
 - **Production:** <https://arthurboss.github.io/WASM-OpenClaw/> — `./scripts/deploy-prod.sh ["msg"]`
 - **Staging:** <https://arthurboss.github.io/WASM-OpenClaw/staging/> — `./scripts/deploy-staging.sh ["msg"]`
@@ -112,454 +44,83 @@ Deploys are manual (no GitHub Actions — billing) via `scripts/`. Both environm
 **Env isolation** (prod + staging share one origin, so storage is scoped deliberately):
 
 - **SW cache** named per scope (`openclaw::<scope>::<version>`) — a version bump in one env can't delete the other's cache; kill-switch teardown is scoped too.
-- **`localStorage`** namespaced by scope: prod keeps bare keys (preserves existing saves), `/staging/` gets a `staging:` prefix. Done via a `Storage.prototype` shim inlined in `<head>` — it **must** stay inline (runs before the save glue baked into `openclaw.js`), unlike `sw-register.js`/`env-marker.js` which are external.
+- **`localStorage`** namespaced by scope: prod keeps bare keys (preserves existing saves), `/staging/` gets a `staging:` prefix. A `Storage.prototype` shim inlined in `<head>` does this — it **must** stay inline (runs before the save glue baked into `openclaw.js`), unlike the external `sw-register.js` / `env-marker.js`.
 - **`IndexedDB`** (`CLAW.REZ` + assets) is intentionally **shared** — staging needs no re-upload.
 - Gold **STAGING** badge marks non-production builds.
 
+## Architecture
 
-## Code Architecture
+### Layout
 
-### Directory Structure
-
-```
-OpenClaw/
-├── OpenClaw/Engine/          # Core C++ engine implementation
-│   ├── Actor/                # Game actor system (player, enemies, items, projectiles)
-│   ├── Audio/                # Sound and music management (Web Audio API for WASM)
-│   ├── Events/               # Event system for game logic communication
-│   ├── GameApp/              # Main loop, game logic, save system, metadata loader
-│   ├── Graphics/             # 2D rendering and image handling
-│   │   ├── WASM/             # WebGL-specific renderer
-│   │   └── Generic/          # Platform-agnostic graphics abstraction
-│   ├── Logger/               # Logging system
-│   ├── Physics/              # Box2D physics integration
-│   ├── Process/              # Process management system
-│   ├── Resource/             # Resource loading/caching (REZ/ZIP archives)
-│   ├── Scene/                # Scene management and level loading
-│   ├── UserInterface/        # UI components and menus
-│   └── Util/                 # Utilities (XML, converters, profilers)
-├── libwap/                   # WAP (game format) file parsing library
-├── Box2D/                    # Physics engine
-├── ThirdParty/               # Dependencies (TinyXML, FastDelegate, sigc++)
-├── Build_Release/            # Output directory
-│   ├── ASSETS/               # Custom assets (source)
-│   ├── ASSETS.ZIP            # Packaged assets (generated)
-│   ├── openclaw.wasm         # Compiled game (~40MB)
-│   ├── openclaw.js           # Emscripten runtime (~8MB)
-│   ├── openclaw.data         # Preloaded assets
-│   ├── openclaw.html         # Game entry point
-│   ├── config.xml            # Game configuration
-│   ├── asset-loader.js       # IndexedDB bridge
-│   ├── asset-storage.js      # Asset storage abstraction
-│   ├── resource-loader.js    # Resource loading coordination
-│   ├── graphics-bridge.js    # WebGL graphics bridge
-│   └── texture-bridge.js     # Texture management bridge
-├── docs/                     # Documentation
-├── scripts/                  # Build and server scripts
-└── emsdk/                    # Emscripten SDK (gitignored)
+```text
+OpenClaw/Engine/       # Core C++ engine
+  Actor/ Audio/ Events/ GameApp/ Physics/ Resource/ Scene/ UserInterface/ Process/ Logger/ Util/
+  Graphics/WASM/       # WebGL renderer (Graphics/Generic/ = platform-agnostic abstraction)
+libwap/ Box2D/ ThirdParty/     # WAP parser, physics, deps (TinyXML, FastDelegate, sigc++)
+Build_Release/         # Output: openclaw.{wasm,js,data,html}, config.xml, *-bridge.js, ASSETS/, ASSETS.ZIP
+scripts/ docs/ emsdk/(gitignored)
 ```
 
-### Key Architectural Patterns
+### Lazy-loading
 
-**Lazy-Loading System:**
+Startup loads only menu/UI assets (~150ms). Level assets and level metadata (XML) load on first entry to each level; a resource cache (default 150 items, in `config.xml`) holds hot assets. Only visited levels consume memory.
 
-- **Startup:** Only loads menu/UI assets (~150ms)
-- **Level Load:** Assets load on-demand when entering levels
-- **Metadata:** Level metadata (XML configs) load lazily on first level entry
-- **Caching:** Resource cache stores frequently accessed assets (default: 150 items)
-- **Result:** Fast startup regardless of game size, only visited levels consume memory
+### Assets & resources
 
-**IndexedDB Asset Storage with Compression:**
+- First run: no `CLAW.REZ` in IndexedDB → upload UI → compress → store (~62MB). Every load: retrieve → decompress (~200-500ms) → mount to FS. Compression auto-selects zstd → brotli → gzip via native `CompressionStream` (gzip in practice today), falling back to uncompressed on failure.
+- `ASSETS.ZIP` is preloaded with the WASM (<1MB) and **overrides** `CLAW.REZ` files with matching paths.
+- Resource paths are **case-sensitive, forward-slash**: `/STATES/MENU/*`, `/GAME/IMAGES/MENU/*`, `/GAME/FONTS/*`, `/LEVEL1..14/*`.
+- Level metadata XMLs are gzip-compressed inside `ASSETS.ZIP`; `XmlLoader.cpp` decompresses transparently. Edit via `scripts/decompress_metadata.sh` → edit → `scripts/compress_metadata.sh`.
 
-**Key concept:** CLAW.REZ (113MB) is NOT bundled in WASM build. It's compressed and stored in IndexedDB.
+### C++/JS bridge
 
-**Flow:**
-
-1. User opens game → Check IndexedDB for CLAW.REZ
-2. If missing → Show upload UI (one-time)
-3. User uploads → Auto-detect best compression (zstd → brotli → gzip) → Store in IndexedDB (~62MB with gzip)
-4. All subsequent loads → Retrieve from IndexedDB → Decompress (~200-500ms) → Mount to FS
-
-**Compression Implementation:**
-
-- Multi-algorithm support: zstd (best) → brotli → gzip (fallback)
-- Uses browser-native `CompressionStream` / `DecompressionStream` APIs
-- Currently uses gzip (as of Chrome 145, zstd/brotli not yet in CompressionStream API)
-- Future-proof: Will automatically use zstd/brotli when browsers add support
-- Compression: One-time during upload, adds 2-5 seconds
-- Decompression: Every game load, adds 200-500ms (~10-20% startup time)
-- Storage savings: 45% reduction with gzip (113MB → 62MB)
-- Automatic fallback to uncompressed if compression/decompression fails
-
-**Files:**
-- `asset-loader.js` - Multi-algorithm compression/decompression and IndexedDB bridge
-- `asset-storage.js` - Stores compression algorithm metadata
-
-**Browser Compatibility:** Chrome 80+, Firefox 113+, Safari 16.4+, Edge 80+ (gzip supported on all)
-
-**Resource Management:**
-
-- CLAW.REZ stored compressed in browser's IndexedDB (one-time upload, 45-70MB compressed)
-- Decompressed to 113MB in memory at game load
-- Resources extracted on-demand when requested (not all at startup)
-- ASSETS.ZIP preloaded with WASM (bundled, <1MB)
-- Path-based organization: `/LEVEL1/*`, `/LEVEL2/*`, etc.
-- Custom assets override CLAW.REZ files with same paths
-
-**Resource Path Conventions:**
-
-**Important:** All resource paths are case-sensitive and use forward slashes:
-
-- Menu assets: `/STATES/MENU/*`, `/GAME/IMAGES/MENU/*`
-- Fonts: `/GAME/FONTS/*`
-- Level assets: `/LEVEL1/*`, `/LEVEL2/*`, etc. (14 levels total)
-- Custom assets in ASSETS.ZIP override CLAW.REZ by matching paths exactly
-
-**Game Loop:**
-
-- Main loop in `GameApp/MainLoop.cpp`
-- Process-based system for game logic updates
-- Event-driven communication between components
-
-**Physics:**
-
-- Box2D integration for platformer physics
-- Separate physics world management
-
-**Audio System:**
-
-- Web Audio API for audio playback in WASM builds
-- All audio loaded from CLAW.REZ via resource system (no HTTP fetches)
-- Memory-safe buffer copying to prevent use-after-free bugs
-- SDL_Mixer for native builds (if any)
-- Configurable sound/music volumes and channels
-
-**Actor System:**
-
-- Component-based actor architecture
-- Actor definitions loaded from XML
-- Various actor types: player, enemies, items, projectiles, triggers, effects
-
-**C++/JavaScript Bridge Pattern:**
-
-**Calling JavaScript from C++:**
-Use `EM_ASM` for inline JavaScript execution:
-
-```cpp
-#include <emscripten.h>
-
-EM_ASM({
-    console.log('Hello from C++');
-    window.someFunction();
-});
-```
-
-**Passing data between C++ and JavaScript:**
-
-```cpp
-// C++ → JS (passing values)
-int result = EM_ASM_INT({
-    return window.someJSFunction($0, $1);
-}, arg1, arg2);
-
-// C++ → JS (strings)
-EM_ASM({
-    console.log('Message: ' + UTF8ToString($0));
-}, message.c_str());
-```
-
-**Key bridge modules:**
-
-- `Build_Release/asset-loader.js` - IndexedDB operations for CLAW.REZ
-- `Build_Release/asset-storage.js` - Asset storage abstraction
-- `Build_Release/graphics-bridge.js` - WebGL graphics bridge
-- `Build_Release/texture-bridge.js` - Texture management
-- `Build_Release/resource-loader.js` - Resource loading coordination
-
-**Pattern:** Bridge files are ES6 modules copied during build (see CMakeLists.txt:69-82). They're imported by the main game HTML and provide JavaScript APIs that C++ code can call via `EM_ASM`.
-
-## Configuration
-
-Game configuration is in `Build_Release/config.xml`:
-
-- Display settings (resolution, fullscreen, vsync, scale)
-- Audio settings (frequency, channels, volumes)
-- Asset paths (REZ archive, custom ZIP)
-- Resource cache size (default: 150, increase for more RAM)
-- Console appearance and behavior
-- Global game options (physics parameters, timing)
+C++ calls JS via `EM_ASM` / `EM_ASM_INT` (strings via `UTF8ToString($0)`). Bridge files in `Build_Release/` are ES6 modules copied at build time, imported by `openclaw.html`: `asset-loader.js` / `asset-storage.js` (IndexedDB + compression), `resource-loader.js` (loading coordination), `graphics-bridge.js` / `texture-bridge.js` (WebGL + textures).
 
 ## Development Workflow
 
-### When to Rebuild
+**When to rebuild:**
 
-**Full rebuild required:**
-
-- Modified C++ source files (`*.cpp`, `*.h`)
-- Changed CMakeLists.txt
-- Updated C++ dependencies (Box2D, libwap)
-- Changed build flags or Emscripten settings
-
-**Partial rebuild (ASSETS.ZIP and relink):**
-
-- Modified XML files in `Build_Release/ASSETS/` (e.g., `MENU.xml`, level XMLs)
-- Changed custom assets in `Build_Release/ASSETS/`
-- **CRITICAL:** ASSETS.ZIP is embedded into `openclaw.data` during the Emscripten linking phase. Simply rebuilding ASSETS.ZIP is NOT enough - you must force a relink!
-- **Complete workflow (required for XML/asset changes):**
+- **Full rebuild** (C++ source, `CMakeLists.txt`, deps, flags): `cd build && make -j$(nproc)`.
+- **JS / HTML / CSS / root `config.xml`**: no rebuild, hard-refresh the browser.
+- **XML or assets under `Build_Release/ASSETS/`**: rebuild `ASSETS.ZIP` **and force a relink** — the #1 silent gotcha. `ASSETS.ZIP` is embedded into `openclaw.data` only during the Emscripten link step, which CMake skips if nothing else changed:
 
   ```bash
-  # Step 1: Decompress metadata for editing (if needed)
-  ./scripts/decompress_metadata.sh
-
-  # Step 2: Edit XMLs
-  # ... make your changes ...
-
-  # Step 3: Compress metadata before rebuild
+  ./scripts/decompress_metadata.sh          # if editing metadata XMLs
+  # ...edit XMLs under Build_Release/ASSETS/ ...
   ./scripts/compress_metadata.sh
-
-  # Step 4: Rebuild ASSETS.ZIP
-  cd Build_Release
-  rm -f ASSETS.ZIP
-  cd ASSETS
-  zip -q -r ../ASSETS.ZIP .
-  cd ../..
-
-  # Step 2: Force CMake to relink (picks up updated ASSETS.ZIP)
-  touch Build_Release/ASSETS.ZIP
-  cd build
-  cmake ..
-  make -j$(nproc)
+  cd Build_Release && rm -f ASSETS.ZIP && (cd ASSETS && zip -q -r ../ASSETS.ZIP .) && cd ..
+  touch Build_Release/ASSETS.ZIP            # forces CMake to relink
+  cd build && cmake .. && make -j$(nproc)
   ```
 
-- **After rebuild:** Hard refresh browser (Ctrl+Shift+R or Cmd+Shift+R) to clear cached WASM files
-- **Why this is needed:** Emscripten embeds ASSETS.ZIP at link time using `--preload-file`. The linking step only runs when CMake detects changes to dependencies. Touching ASSETS.ZIP forces CMake to detect it as modified and trigger a relink.
+**Never commit build artifacts:** `build/`, `Build_Release/openclaw.{wasm,js,data}`, `Build_Release/ASSETS.ZIP`, `emsdk/`.
 
-**No rebuild needed (just refresh browser):**
+**Testing:** no automated tests. Build → `yarn dev` → check browser console for JS errors and C++ `LOG` output → play affected levels. In-game console (`~`): `reload levelmetadata`.
 
-- Modified JavaScript files (`*.js` in Build_Release/)
-- Modified HTML (`openclaw.html`)
-- Modified CSS styles
-- Changed `config.xml` (root level, not in ASSETS/)
-- Updated documentation
+## Key Files
 
-### Incremental Builds
-
-After first build, only modified files recompile:
-
-```bash
-source ./emsdk/emsdk_env.sh
-cd build
-make -j$(nproc)
-```
-
-### Clean Build
-
-To start fresh:
-
-```bash
-rm -rf build
-./build_wasm.sh
-```
-
-### Build Artifacts (Gitignored)
-
-Never commit these generated files:
-
-- `build/` - CMake build directory
-- `Build_Release/openclaw.{wasm,js,data}` - Compiled outputs
-- `emsdk/` - Emscripten SDK (large, user-installed)
-- `Build_Release/ASSETS.ZIP` - Auto-generated from ASSETS/
-
-## Testing
-
-This project does not have automated tests. Verify changes by:
-
-1. **Build:** Run `./build_wasm.sh` to compile changes
-2. **Run:** Start the dev server (`yarn dev`)
-3. **Browser Console:** Check for JavaScript errors and warnings (F12)
-4. **Manual Testing:** Play through affected levels/features
-5. **Log Output:** Watch browser console for C++ logs (uses `LOG` macro)
-
-## Key Implementation Files
-
-### Lazy Loading
-
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:173` - Startup (skips eager metadata load)
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1356` - `LoadSingleLevelMetadata()`
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1545` - `GetLevelMetadata()` (with lazy load)
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:186-196` - VPreload calls (startup assets)
-
-### Asset Management
-
-- `OpenClaw/Engine/Resource/ResourceMgr.cpp` - Resource manager implementation
-- `OpenClaw/Engine/Resource/ResourceCache.cpp` - Resource caching logic
-- `Build_Release/asset-loader.js` - IndexedDB bridge for CLAW.REZ
-- `Build_Release/asset-storage.js` - Asset storage abstraction layer
-- `Build_Release/resource-loader.js` - Resource loading coordination
-
-### Graphics System
-
-- `OpenClaw/Engine/Graphics/WASM/PureWebGLRenderer.cpp` - WebGL renderer
-- `OpenClaw/Engine/Graphics/WASM/TextureManager.cpp` - Texture loading/management
-- `Build_Release/graphics-bridge.js` - Graphics system bridge
-- `Build_Release/texture-bridge.js` - Texture management bridge
-
-### Audio System
-
-- `OpenClaw/Engine/Audio/WebAudioAPI.cpp` - Web Audio API integration
-- `OpenClaw/Engine/Audio/WASM/AudioWorkletSystem.cpp` - Audio playback from CLAW.REZ data
-- `OpenClaw/Engine/Resource/Loaders/WavLoader.cpp` - WAV loading with memory-safe buffer copying
-- `OpenClaw/Engine/UserInterface/HumanView.cpp:641` - Sound playback delegation
-- `OpenClaw/Engine/UserInterface/HumanView.cpp:562` - MIDI handling (disabled for Emscripten)
-
-### Metadata Compression
-
-- Level metadata XMLs are gzip-compressed to reduce ASSETS.ZIP size by ~79%
-- `OpenClaw/Engine/Resource/Loaders/XmlLoader.cpp` - Automatic gzip decompression
-- `scripts/compress_metadata.sh` - Compress XMLs before build
-- `scripts/decompress_metadata.sh` - Decompress XMLs for editing
-
-**Compression results:**
-
-- Original: 28,895 bytes (13 XML files)
-- Compressed: 5,955 bytes (79.4% smaller)
-- Runtime: ~0.1ms decompression per file (negligible impact)
+- **Lazy loading:** `BaseGameApp.cpp` — startup skips eager metadata (:173), `VPreload` startup assets (:186-196), `LoadSingleLevelMetadata()` (:1356), `GetLevelMetadata()` lazy (:1545).
+- **Assets:** `Resource/ResourceMgr.cpp`, `Resource/ResourceCache.cpp`.
+- **Graphics:** `Graphics/WASM/PureWebGLRenderer.cpp`, `Graphics/WASM/TextureManager.cpp`.
+- **Audio:** `Audio/WebAudioAPI.cpp`, `Audio/WASM/AudioWorkletSystem.cpp`, `Resource/Loaders/WavLoader.cpp` (memory-safe buffer copies); `HumanView.cpp` sound (:641), MIDI disabled for Emscripten (:562).
+- **Metadata:** `Resource/Loaders/XmlLoader.cpp`.
 
 ## Build Configuration
 
-### CMake Options
-
 ```bash
-emcmake cmake -DEmscripten=1 ..                    # WebAssembly mode
-emcmake cmake -DEmscripten=1 -DExtern_Config=0 ..  # Embed config.xml in WASM
+emcmake cmake -DEmscripten=1 ..                     # WASM mode
+emcmake cmake -DEmscripten=1 -DExtern_Config=0 ..   # embed config.xml in WASM
 ```
 
-### Emscripten Flags (in CMakeLists.txt)
-
-Key flags set in CMakeLists.txt line 98:
-
-```cmake
--s WASM=1                    # WebAssembly output
--s USE_SDL=2                 # SDL2 support
--s USE_SDL_IMAGE=2           # SDL2_image
--s USE_SDL_TTF=2             # SDL2_ttf
--s USE_SDL_GFX=2             # SDL2_gfx
--s USE_SDL_MIXER=2           # SDL2_mixer
--s ASYNCIFY=1                # Enable async operations
--s TOTAL_MEMORY=268435456    # 256MB memory allocation
--s ALLOW_MEMORY_GROWTH=1     # Dynamic memory growth
--s FULL_ES3=1                # WebGL2 support
--s USE_WEBGL2=1              # WebGL2 API
--s MIN_WEBGL_VERSION=2       # Minimum WebGL version
--s MAX_WEBGL_VERSION=2       # Maximum WebGL version
--s USE_ZLIB=1                # Enable zlib for gzip decompression
--s FETCH                     # Enable fetch API for async loading
-```
-
-**Preloaded files:**
-
-- `ASSETS.ZIP` - Custom assets bundle
-- `console02.tga` - Console background
-- `clacon.ttf` - Console font
-
-**Note:** CLAW.REZ is explicitly NOT preloaded (lazy-loaded from IndexedDB).
-
-## Testing and Debugging
-
-### Browser Console Logs
-
-**Startup (should see):**
-
-```
-INFO: Loading critical assets (menu/UI)...
-INFO: Critical assets loaded. Level assets will load on-demand.
-INFO: Actor prototypes loaded successfully.
-```
-
-**First level entry (should see):**
-
-```
-INFO: Loading assets for LEVEL2...
-INFO: Level assets loaded for LEVEL2
-INFO: Requesting metadata for level 2
-INFO: Lazy-loaded metadata for level 2
-```
-
-**Second level entry (should NOT see metadata messages):**
-
-```
-INFO: Loading assets for LEVEL2...
-INFO: Level assets loaded for LEVEL2
-```
-
-### Console Commands
-
-In-game console (press ~ key):
-
-- `reload levelmetadata` - Reloads all metadata files (development feature)
-
-### Common Issues
-
-**Black screen:**
-
-1. Open browser console (F12)
-2. Check for WebGL errors
-3. Verify SDL2 shaders were patched correctly
-4. Check if CLAW.REZ upload completed successfully
-
-**Asset loading errors:**
-
-1. Verify CLAW.REZ is in IndexedDB (check Application tab in DevTools)
-2. Clear IndexedDB and re-upload CLAW.REZ
-3. Check resource paths are case-sensitive and use forward slashes
+Emscripten flags live in `CMakeLists.txt` (SDL2 + image/ttf/gfx/mixer, `ASYNCIFY`, 256MB memory with growth, WebGL2, `USE_ZLIB`, `FETCH`). Preloaded: `ASSETS.ZIP`, `console02.tga`, `clacon.ttf`. `CLAW.REZ` is explicitly **not** preloaded.
 
 ## Known Limitations
 
-**Browser-Specific:**
+- MIDI audio not supported on WASM (WAV/OGG fine).
+- Firefox: ALT opens the window menu (browser bug) — use fullscreen.
+- Death/teleport fade effects can have rendering quirks.
 
-- Firefox ALT key opens window menu (browser bug) - use fullscreen or disable in about:config
-- Microsoft Edge may have WAV playback issues in older versions
+## Docs & References
 
-**WASM Platform:**
-
-- MIDI audio not yet supported (WAV/OGG work fine). Might add Web MIDI support
-- Death/teleport fade effects may have rendering quirks
-
-## Recent Changes
-
-- **Vite dev server**: Local development with hot reload, clean URLs, no cert warnings
-  - SSH tunnel for secure context (Keyboard Lock API works on localhost)
-  - HTTP port 5173 (no self-signed cert complexity)
-- **Audio system fix**: Fixed use-after-free bug causing game sounds to fail with "Invalid WAV header" errors
-  - All sounds now load directly from CLAW.REZ via data parameter
-  - Eliminated duplicate audio files and HTTP fetch overhead
-  - Proper memory management with buffer copying in WavLoader
-- Lazy-loading architecture for faster startup
-- Brotli/Zstd compression for optimal transfer size
-- SDL2 shader patches for WebGL compatibility
-- IndexedDB storage for CLAW.REZ (one-time upload)
-- Volume defaults optimized for browser playback
-
-## Documentation
-
-See `docs/` directory for detailed information:
-
-**For Players (`docs/player/`):**
-
-- **GAMEPAD.md** - Controller setup and vibration feedback
-- **TROUBLESHOOTING.md** - Common issues and solutions
-
-**For Developers (`docs/developer/`):**
-
-- **BUILDING.md** - Complete build guide
-- **ARCHITECTURE.md** - Technical architecture and lazy-loading design
-- **SAVE_SYSTEM.md** - localStorage save implementation
-- **HAPTIC_FEEDBACK.md** - Gamepad vibration system
-- **SCREEN_RENDERING.md** - UI and screen code locations
-- **GENERIC_GRAPHICS.md** - Cross-platform graphics module
-
-## References
-
-- Original OpenClaw: <https://github.com/pjasicek/OpenClaw>
-- Emscripten Documentation: <https://emscripten.org/docs/>
-- SDL2 Documentation: <https://wiki.libsdl.org/>
+- `docs/` — player (`GAMEPAD.md`, `TROUBLESHOOTING.md`), developer (`BUILDING.md`, `ARCHITECTURE.md`, `SAVE_SYSTEM.md`, `HAPTIC_FEEDBACK.md`, `SCREEN_RENDERING.md`, `GENERIC_GRAPHICS.md`).
+- Original OpenClaw: <https://github.com/pjasicek/OpenClaw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,43 @@ The dev server starts on `http://localhost:5173/`
 - No certificate warnings
 
 
+## Deployment (GitHub Pages)
+
+GitHub Actions is unavailable on this account (billing), so deploys are manual via the committed scripts in `scripts/`. Both environments live on the single `gh-pages` branch — **production at the root**, **staging under `/staging/`** — and neither script can clobber the other (`deploy-prod.sh` excludes `staging/` from its `--delete`; `deploy-staging.sh` writes only `/staging/`).
+
+- **Production:** <https://arthurboss.github.io/WASM-OpenClaw/>
+- **Staging:** <https://arthurboss.github.io/WASM-OpenClaw/staging/>
+
+```bash
+# Deploy current Build_Release/ to production (root)
+./scripts/deploy-prod.sh ["commit msg"]
+
+# Deploy current Build_Release/ to staging (/staging/ only)
+./scripts/deploy-staging.sh ["commit msg"]
+```
+
+Both scripts verify the WASM artifact set is fresh (guarding the `ASM_CONSTS` boot crash from a stale/mismatched loader+wasm pair) and clean up their temp worktree on exit.
+
+### Default workflow: deploy every branch to staging
+
+**When working on a new branch, deploy it to staging by default** so it can be tested on a real device (especially mobile) before merging. Staging never touches production, so this is safe. The loop:
+
+1. Build on the VM; make changes in `Build_Release/`.
+2. `./scripts/deploy-staging.sh` → test at the staging URL.
+3. Once verified, merge the PR, then `./scripts/deploy-prod.sh` to promote to production.
+
+Skip staging only for deploy-only/non-visual changes, or when the change cannot be exercised in the browser.
+
+### Environment isolation
+
+Production and staging share one origin (`arthurboss.github.io`), so origin-scoped web storage is isolated deliberately:
+
+- **Service worker cache** is named per deployment scope (`openclaw::<scope>::<version>`), so a version bump in one environment cannot delete the other's cache. The kill-switch teardown is likewise scoped to its own environment.
+- **`localStorage`** is namespaced by scope: production keeps bare keys (preserving existing users' saves); `/staging/` gets a `staging:` prefix. This covers game saves, the install-onboarding flag, touch-mode, and the SW kill-switch id. Implemented as a `Storage.prototype` shim inlined in `<head>` (must run before the save glue baked into `openclaw.js`), so it stays inline while `sw-register.js`/`env-marker.js` are external.
+- **`IndexedDB`** (the uploaded `CLAW.REZ` and assets) is intentionally **shared**, so staging does not require re-uploading the game file.
+- A gold **STAGING** badge marks non-production builds so they can't be confused with prod.
+
+
 ## Code Architecture
 
 ### Directory Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ OpenClaw WASM is a browser-based fork of Captain Claw (1997), focused on optimiz
 
 - **`CLAW.REZ`** — original game archive (~113MB, uploaded at runtime, not in repo).
 - **`ASSETS.ZIP`** — custom assets, auto-generated from `Build_Release/ASSETS/`.
-- Emscripten SDK (`emsdk/`, gitignored), CMake 4.10+, Node.js 18+ (Vite).
+- Emscripten SDK (`emsdk/`, gitignored), CMake 4.3.2+, Node.js 18+ (Vite).
 - Browsers: Chrome 105+ / Firefox 121+ / Safari 16.4+ / Edge 105+.
 
 ## Build

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -7,7 +7,7 @@ This guide covers building the WebAssembly version of OpenClaw from source.
 ### Required Tools
 
 - **Emscripten SDK** - Compiles C++ to WebAssembly
-- **CMake** 4.10+
+- **CMake** 4.3.2+
 - **Python 3** - For local testing server
 - **Git** - For cloning dependencies
 

--- a/scripts/_deploy-lib.sh
+++ b/scripts/_deploy-lib.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Shared helpers for the gh-pages deploy scripts (prod + staging).
+# Sourced by deploy-prod.sh and deploy-staging.sh. Not meant to run standalone.
+#
+# gh-pages layout on origin:
+#   /            -> production (served at https://arthurboss.github.io/WASM-OpenClaw/)
+#   /staging/    -> staging    (served at .../WASM-OpenClaw/staging/)
+# Both live on the single origin/gh-pages branch. deploy-prod excludes staging/
+# from its --delete; deploy-staging scopes its rsync target to staging/ only.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$REPO_DIR/Build_Release"
+WORKTREE="/tmp/gh-pages-deploy"
+GH_BRANCH="gh-pages"
+
+# Files inside Build_Release/ that must never be published to gh-pages.
+RSYNC_EXCLUDES=(
+  --exclude=".git"
+  --exclude="ASSETS/"
+  --exclude="ASSETS.ZIP"
+  --exclude="Makefile"
+  --exclude="SAVES.XML"
+  --exclude="config_linux.xml"
+  --exclude="config_linux_release.xml"
+  --exclude="startup_commands.txt"
+  --exclude="ClawLauncher.exe.config"
+)
+
+log()  { printf '\033[1;34m[deploy]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[deploy]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[deploy] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Verify the version-locked WASM artifact set exists and is fresh. openclaw.js
+# calls into openclaw.wasm by address (ASM_CONSTS); a stale .js against a fresh
+# .wasm crashes at boot with "ASM_CONSTS[emAsmAddr] is not a function". We guard
+# by (a) requiring all three artifacts to exist and be non-empty, (b) requiring
+# each to be newer than the newest C++ source under OpenClaw/, and (c) requiring
+# the three to share a build window (mtimes within 10 min) so a partially
+# rebuilt set is caught. Abort with instructions rather than ship a mismatch.
+verify_wasm_fresh() {
+  local artifacts=("$BUILD_DIR/openclaw.wasm" "$BUILD_DIR/openclaw.js" "$BUILD_DIR/openclaw.data")
+  local a
+  for a in "${artifacts[@]}"; do
+    [ -s "$a" ] || die "Missing or empty artifact: $a
+  Rebuild first:  source ~/emsdk/emsdk_env.sh && cd $REPO_DIR/build && make -j\$(nproc)"
+  done
+
+  local newest_src
+  newest_src=$(find "$REPO_DIR/OpenClaw" -type f \
+      \( -name '*.cpp' -o -name '*.cxx' -o -name '*.h' -o -name '*.hpp' -o -name '*.c' \) \
+      -printf '%T@\n' 2>/dev/null | sort -n | tail -1)
+  newest_src=${newest_src%.*}   # strip sub-second fraction
+
+  local min="" max="" m
+  for a in "${artifacts[@]}"; do
+    m=$(stat -c %Y "$a")
+    if [ -n "$newest_src" ] && [ "$m" -lt "$newest_src" ]; then
+      die "Stale artifact: $(basename "$a") is older than the newest source in OpenClaw/.
+  The deployed loader/wasm would mismatch (ASM_CONSTS crash). Rebuild first:
+    source ~/emsdk/emsdk_env.sh && cd $REPO_DIR/build && make -j\$(nproc)"
+    fi
+    if [ -z "$min" ] || [ "$m" -lt "$min" ]; then min=$m; fi
+    if [ -z "$max" ] || [ "$m" -gt "$max" ]; then max=$m; fi
+  done
+
+  if [ $(( max - min )) -gt 600 ]; then
+    die "WASM artifacts span $(( max - min ))s of build time (>10min apart).
+  openclaw.wasm/.js/.data look like they came from different builds and may
+  mismatch at boot. Do a clean rebuild before deploying."
+  fi
+  log "WASM artifact set verified fresh (built within $(( max - min ))s window)."
+}
+
+# Create a fresh temp worktree tracking origin/gh-pages, with a local branch
+# literally named 'gh-pages' so the global pre-push hook (which requires the
+# local branch name to match the remote target) permits the push.
+setup_worktree() {
+  cd "$REPO_DIR"
+  git worktree remove "$WORKTREE" --force 2>/dev/null || true
+  git branch -D "$GH_BRANCH" 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+  git config --global --get-all safe.directory | grep -qx "$WORKTREE" \
+    || git config --global --add safe.directory "$WORKTREE"
+  log "Fetching origin/$GH_BRANCH ..."
+  git fetch origin "$GH_BRANCH"
+  git worktree add "$WORKTREE" -b "$GH_BRANCH" "origin/$GH_BRANCH" >/dev/null
+}
+
+cleanup_worktree() {
+  cd "$REPO_DIR" 2>/dev/null || return 0
+  git worktree remove "$WORKTREE" --force 2>/dev/null || true
+  git branch -D "$GH_BRANCH" 2>/dev/null || true
+  git worktree prune 2>/dev/null || true
+}
+
+# Commit staged content in the worktree and push. Skips cleanly if nothing
+# changed. Verifies the local branch tracks the right remote before pushing.
+commit_and_push() {
+  local msg="$1"
+  cd "$WORKTREE"
+  git add -A
+  if git diff --cached --quiet; then
+    log "No changes to publish. Skipping commit/push."
+    return 0
+  fi
+  git commit -m "$msg" >/dev/null
+  local tracking
+  tracking=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+  log "Local branch: $(git symbolic-ref --short HEAD)  ->  tracking: ${tracking:-<none>}"
+  log "Pushing to origin/$GH_BRANCH ..."
+  git push origin "$GH_BRANCH"
+  log "Pushed. GitHub Pages will update in ~1 min."
+}

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Deploy Build_Release/ to the ROOT of origin/gh-pages == PRODUCTION.
+#   https://arthurboss.github.io/WASM-OpenClaw/
+#
+# Safe against staging: the rsync --delete explicitly EXCLUDES staging/, so a
+# production deploy never touches the /staging/ subdirectory.
+#
+# Usage:  scripts/deploy-prod.sh ["commit message"]
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/_deploy-lib.sh"
+
+MSG="${1:-chore: deploy master to gh-pages (production)}"
+
+trap cleanup_worktree EXIT
+
+verify_wasm_fresh
+setup_worktree
+
+log "Syncing Build_Release/ -> gh-pages root (preserving staging/) ..."
+rsync -a --delete --exclude="staging/" "${RSYNC_EXCLUDES[@]}" \
+  "$BUILD_DIR/" "$WORKTREE/"
+
+# GitHub Pages serves / from index.html; the game entry point is openclaw.html.
+cp "$BUILD_DIR/openclaw.html" "$WORKTREE/index.html"
+
+commit_and_push "$MSG"
+log "Production live at: https://arthurboss.github.io/WASM-OpenClaw/"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Deploy Build_Release/ to the /staging/ subdirectory of origin/gh-pages.
+#   https://arthurboss.github.io/WASM-OpenClaw/staging/
+#
+# Safe against production: the rsync --delete target is scoped to the staging/
+# subdirectory only, so it can never remove or modify any root (production)
+# file. The PWA uses relative paths (manifest scope "./", SW registers with
+# scope "./"), so the staging service worker registers with scope
+# /WASM-OpenClaw/staging/ and cannot cache or interfere with production's
+# root-scoped SW. staging/sw-control.json is its own kill-switch copy.
+#
+# Usage:  scripts/deploy-staging.sh ["commit message"]
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/_deploy-lib.sh"
+
+MSG="${1:-chore: deploy to gh-pages /staging/}"
+
+trap cleanup_worktree EXIT
+
+verify_wasm_fresh
+setup_worktree
+
+mkdir -p "$WORKTREE/staging"
+
+log "Syncing Build_Release/ -> gh-pages /staging/ (root untouched) ..."
+rsync -a --delete "${RSYNC_EXCLUDES[@]}" \
+  "$BUILD_DIR/" "$WORKTREE/staging/"
+
+# Entry point for /staging/ (mirrors how root uses index.html).
+cp "$BUILD_DIR/openclaw.html" "$WORKTREE/staging/index.html"
+
+commit_and_push "$MSG"
+log "Staging live at: https://arthurboss.github.io/WASM-OpenClaw/staging/"


### PR DESCRIPTION
- Adds a staging environment on GitHub Pages served from `/staging/`, alongside production at the root, so PWA changes can be tested on-device before going live: staging at `https://arthurboss.github.io/WASM-OpenClaw/staging/`
- Two committed deploy scripts (`scripts/deploy-prod.sh`, `scripts/deploy-staging.sh`) replace the manual deploy command: prod excludes `staging/` from its `--delete` and staging scopes its sync to `staging/` only, so neither can ever clobber the other
- Both scripts guard against shipping a stale or mismatched WASM artifact set (the `ASM_CONSTS` boot crash) and clean up their temp worktree even on failure
- Isolates PWA web storage per deployment now that prod and staging share one origin: the service worker cache name is scoped to its own registration path so a version bump in one environment cannot wipe the other's cache, and `localStorage` is namespaced by scope (production keeps bare keys so existing saves are preserved; sub-paths like `/staging/` get a prefix), keeping saves, the install-onboarding flag, and the SW kill-switch id from colliding
- Scopes the kill-switch teardown to its own environment so tripping staging's switch never unregisters production's service worker or clears its caches
- Adds a `STAGING` corner badge to non-production builds so environments are unmistakable
- `CLAW.REZ` in IndexedDB stays intentionally shared across environments, so staging does not require a re-upload