### PR TITLE
refactor: rename OpenClaw to Captain Claw Web

### DIFF
--- a/Build_Release/asset-storage.js
+++ b/Build_Release/asset-storage.js
@@ -4,31 +4,33 @@
  */
 export class AssetStorage {
   constructor() {
-    this.dbName = 'Captain ClawAssets';
+    this.dbName = 'CaptainClawWebAssets';
+    // Pre-rename database name. Existing users have their uploaded CLAW.REZ
+    // here; init() migrates it once so nobody has to re-upload ~113MB.
+    this.legacyDbName = 'OpenClawAssets';
     this.storeName = 'files';
     this.db = null;
     this.chunkSize = 1024 * 1024 * 5; // 5MB chunks to prevent memory issues
   }
 
   /**
-   * Initialize IndexedDB connection
+   * Initialize IndexedDB connection, migrating from the legacy database on
+   * first run so a returning user keeps their stored CLAW.REZ.
    * @returns {Promise<void>}
    */
   async init() {
+    this.db = await this._open(this.dbName);
+    await this._migrateFromLegacy();
+  }
+
+  /** Open (and create/upgrade) a database by name. */
+  _open(name) {
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, 1);
-
-      request.onerror = () => reject(new Error('Failed to open IndexedDB'));
-
-      request.onsuccess = (event) => {
-        this.db = event.target.result;
-        resolve();
-      };
-
+      const request = indexedDB.open(name, 1);
+      request.onerror = () => reject(new Error('Failed to open IndexedDB: ' + name));
+      request.onsuccess = (event) => resolve(event.target.result);
       request.onupgradeneeded = (event) => {
         const db = event.target.result;
-
-        // Create object store if it doesn't exist
         if (!db.objectStoreNames.contains(this.storeName)) {
           const objectStore = db.createObjectStore(this.storeName, { keyPath: 'name' });
           objectStore.createIndex('name', 'name', { unique: true });
@@ -36,6 +38,63 @@ export class AssetStorage {
         }
       };
     });
+  }
+
+  /**
+   * One-time migration of all records from the legacy DB into the current DB.
+   * Runs only when the current DB is empty and the legacy DB has data, so it
+   * is a no-op for new users and for anyone already migrated. The legacy DB is
+   * deleted afterwards. Any failure is swallowed: migration is best-effort and
+   * must never block startup (the user can always re-upload as a fallback).
+   */
+  async _migrateFromLegacy() {
+    try {
+      // Skip if we already have data (already migrated or a fresh upload).
+      const existing = await new Promise((resolve) => {
+        const tx = this.db.transaction([this.storeName], 'readonly');
+        const req = tx.objectStore(this.storeName).getAllKeys();
+        req.onsuccess = (e) => resolve(e.target.result || []);
+        req.onerror = () => resolve([]);
+      });
+      if (existing.length > 0) return;
+
+      // Does the legacy DB exist? databases() isn't in every browser, so fall
+      // back to opening it and checking for our store.
+      if (indexedDB.databases) {
+        const dbs = await indexedDB.databases();
+        if (!dbs.some((d) => d.name === this.legacyDbName)) return;
+      }
+
+      const legacy = await this._open(this.legacyDbName);
+      if (!legacy.objectStoreNames.contains(this.storeName)) {
+        legacy.close();
+        return;
+      }
+
+      const records = await new Promise((resolve) => {
+        const tx = legacy.transaction([this.storeName], 'readonly');
+        const req = tx.objectStore(this.storeName).getAll();
+        req.onsuccess = (e) => resolve(e.target.result || []);
+        req.onerror = () => resolve([]);
+      });
+
+      if (records.length > 0) {
+        await new Promise((resolve, reject) => {
+          const tx = this.db.transaction([this.storeName], 'readwrite');
+          const store = tx.objectStore(this.storeName);
+          records.forEach((r) => store.put(r));
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error);
+        });
+        console.info('[migrate] Moved ' + records.length + ' asset record(s) from ' + this.legacyDbName + '.');
+      }
+
+      legacy.close();
+      // Remove the old DB now that its contents are safely copied.
+      indexedDB.deleteDatabase(this.legacyDbName);
+    } catch (e) {
+      console.warn('[migrate] Legacy IndexedDB migration skipped:', e);
+    }
   }
 
   /**

--- a/Build_Release/asset-storage.js
+++ b/Build_Release/asset-storage.js
@@ -4,7 +4,7 @@
  */
 export class AssetStorage {
   constructor() {
-    this.dbName = 'OpenClawAssets';
+    this.dbName = 'Captain ClawAssets';
     this.storeName = 'files';
     this.db = null;
     this.chunkSize = 1024 * 1024 * 5; // 5MB chunks to prevent memory issues

--- a/Build_Release/captain-claw-web.html
+++ b/Build_Release/captain-claw-web.html
@@ -12,7 +12,7 @@
          users' saved games are preserved untouched; only sub-path
          deployments (staging, previews) get a prefix. This runs before any
          other script, so it also transparently covers the save-data glue
-         baked into captain-claw-web.js (from SaveBridge.cpp) which we cannot edit
+         baked into openclaw.js (from SaveBridge.cpp) which we cannot edit
          without a C++ rebuild. IndexedDB (CLAW.REZ + assets) is intentionally
          NOT namespaced — it stays shared across environments. -->
     <script>
@@ -21,21 +21,48 @@
         var m = path.match(/\/staging\//);
         // Only sub-path environments get a prefix; production stays bare.
         var PREFIX = m ? "staging:" : "";
-        if (!PREFIX) return; // production: no-op, native localStorage
+        if (PREFIX) {
+          try {
+            var proto = Object.getPrototypeOf(window.localStorage);
+            var raw = {
+              get: proto.getItem,
+              set: proto.setItem,
+              remove: proto.removeItem,
+            };
+            var wrap = function (k) { return PREFIX + k; };
+            proto.getItem = function (k) { return raw.get.call(this, wrap(k)); };
+            proto.setItem = function (k, v) { return raw.set.call(this, wrap(k), v); };
+            proto.removeItem = function (k) { return raw.remove.call(this, wrap(k)); };
+            console.info("[env] localStorage namespaced with prefix \"" + PREFIX + "\"");
+          } catch (e) {
+            console.warn("[env] Could not namespace localStorage:", e);
+          }
+        }
+      })();
+    </script>
+
+    <!-- One-time save-data migration. The save key was renamed from the
+         pre-rebrand 'openclaw:saves' to 'captain-claw-web:saves' (matched in
+         SaveBridge.cpp). Copy an existing legacy save into the new key once so
+         returning players keep their progress, then remove the old key. Runs
+         AFTER the env shim above so the prefix (on staging) applies to both
+         keys consistently. Guarded to act only when the new key is empty and a
+         legacy value exists. -->
+    <script>
+      (function () {
         try {
-          var proto = Object.getPrototypeOf(window.localStorage);
-          var raw = {
-            get: proto.getItem,
-            set: proto.setItem,
-            remove: proto.removeItem,
-          };
-          var wrap = function (k) { return PREFIX + k; };
-          proto.getItem = function (k) { return raw.get.call(this, wrap(k)); };
-          proto.setItem = function (k, v) { return raw.set.call(this, wrap(k), v); };
-          proto.removeItem = function (k) { return raw.remove.call(this, wrap(k)); };
-          console.info("[env] localStorage namespaced with prefix \"" + PREFIX + "\"");
+          var OLD = "openclaw:saves";
+          var NEW = "captain-claw-web:saves";
+          if (localStorage.getItem(NEW) === null) {
+            var legacy = localStorage.getItem(OLD);
+            if (legacy !== null) {
+              localStorage.setItem(NEW, legacy);
+              localStorage.removeItem(OLD);
+              console.info("[migrate] Copied legacy save data to '" + NEW + "'.");
+            }
+          }
         } catch (e) {
-          console.warn("[env] Could not namespace localStorage:", e);
+          console.warn("[migrate] Save-data migration skipped:", e);
         }
       })();
     </script>
@@ -1544,7 +1571,7 @@
          marker. Both are defer-safe (they act on window 'load' or at end of
          parse), so external + defer is fine. The localStorage-isolation shim
          stays INLINE in <head> because it must patch Storage.prototype before
-         any other script (incl. the save glue baked into captain-claw-web.js) runs. -->
+         any other script (incl. the save glue baked into openclaw.js) runs. -->
     <script src="sw-register.js" defer></script>
     <script src="env-marker.js" defer></script>
   </body>

--- a/Build_Release/captain-claw-web.html
+++ b/Build_Release/captain-claw-web.html
@@ -67,13 +67,13 @@
       })();
     </script>
 
-    <title>Captain Claw</title>
+    <title>Captain Claw Web</title>
     <meta
       name="description"
       content="Reimplementation of Captain Claw (1997) platformer"
     />
 
-    <meta property="og:title" content="Captain Claw" />
+    <meta property="og:title" content="Captain Claw Web" />
     <meta property="og:description" content="Play Captain Claw (1997) in your web browser" />
     <!--<meta property="og:image" content="preview.png">-->
 
@@ -87,7 +87,7 @@
     <!-- iOS PWA: standalone fullscreen mode, hides Safari chrome when added to Home Screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Captain Claw" />
+    <meta name="apple-mobile-web-app-title" content="Captain Claw Web" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />
 
@@ -734,7 +734,7 @@
               class="control-btn"
               id="pwa-install-control"
               title="Install App"
-              aria-label="Install Captain Claw"
+              aria-label="Install Captain Claw Web"
               style="display: none"
             >
               <svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
@@ -756,10 +756,10 @@
       <div class="onboard-card">
         <div class="onboard-emoji">🎮</div>
         <span id="installBadge" class="onboard-badge">&nbsp;</span>
-        <h2>Install Captain Claw?</h2>
-        <p id="installReason">Install Captain Claw for the best experience.</p>
+        <h2>Install Captain Claw Web?</h2>
+        <p id="installReason">Install Captain Claw Web for the best experience.</p>
         <div class="onboard-actions">
-          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install Captain Claw</button>
+          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install Captain Claw Web</button>
           <button class="btn btn-ghost" id="installSkipBtn">Not now</button>
         </div>
       </div>
@@ -1411,7 +1411,7 @@
           if (isIOSSafari) {
             return {
               level: 'recommended',
-              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch Captain Claw straight from your home screen.'
+              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch Captain Claw Web straight from your home screen.'
             };
           }
           if (isSamsungBrowser) {
@@ -1430,7 +1430,7 @@
           }
           return {
             level: 'optional',
-            reason: 'On desktop, Captain Claw already runs great in the browser. Installing simply opens it in its own dedicated window.'
+            reason: 'On desktop, Captain Claw Web already runs great in the browser. Installing simply opens it in its own dedicated window.'
           };
         }
 
@@ -1451,21 +1451,21 @@
           }
           if (isIOSSafari) {
             alert(
-              'Install Captain Claw on iOS:\n\n' +
+              'Install Captain Claw Web on iOS:\n\n' +
               '1. Tap the Share button at the bottom of Safari\n' +
               '2. Choose “Add to Home Screen”\n' +
               '3. Tap “Add” — the game launches fullscreen.'
             );
           } else if (isMacSafari) {
             alert(
-              'Install Captain Claw on Mac:\n\n' +
+              'Install Captain Claw Web on Mac:\n\n' +
               '1. Open the File menu in Safari\n' +
               '2. Choose “Add to Dock…”\n' +
               '3. Confirm — the game opens in its own window.'
             );
           } else {
             alert(
-              'Install Captain Claw:\n\n' +
+              'Install Captain Claw Web:\n\n' +
               'Open your browser menu and choose “Install app”,\n' +
               '“Add to Home Screen”, or “Create shortcut”.\n\n' +
               'The game will then open in its own fullscreen window.'

--- a/Build_Release/captain-claw-web.html
+++ b/Build_Release/captain-claw-web.html
@@ -5,14 +5,14 @@
 
     <!-- Per-environment localStorage isolation. GitHub Pages serves every
          deployment from ONE origin, and localStorage is origin-scoped, so
-         production (/WASM-OpenClaw/) and staging (/WASM-OpenClaw/staging/)
+         production (/captain-claw-web/) and staging (/captain-claw-web/staging/)
          would otherwise share one key space: game saves, install-onboarding
          flag, touch-mode, and the SW kill-switch id would all collide.
          We namespace keys by scope. PRODUCTION KEEPS BARE KEYS so existing
          users' saved games are preserved untouched; only sub-path
          deployments (staging, previews) get a prefix. This runs before any
          other script, so it also transparently covers the save-data glue
-         baked into openclaw.js (from SaveBridge.cpp) which we cannot edit
+         baked into captain-claw-web.js (from SaveBridge.cpp) which we cannot edit
          without a C++ rebuild. IndexedDB (CLAW.REZ + assets) is intentionally
          NOT namespaced — it stays shared across environments. -->
     <script>
@@ -40,14 +40,14 @@
       })();
     </script>
 
-    <title>OpenClaw</title>
+    <title>Captain Claw</title>
     <meta
       name="description"
       content="Reimplementation of Captain Claw (1997) platformer"
     />
 
-    <meta property="og:title" content="OpenClaw project" />
-    <meta property="og:description" content="OpenClaw open source project" />
+    <meta property="og:title" content="Captain Claw" />
+    <meta property="og:description" content="Play Captain Claw (1997) in your web browser" />
     <!--<meta property="og:image" content="preview.png">-->
 
     <!-- Favicons -->
@@ -60,7 +60,7 @@
     <!-- iOS PWA: standalone fullscreen mode, hides Safari chrome when added to Home Screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="OpenClaw" />
+    <meta name="apple-mobile-web-app-title" content="Captain Claw" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />
 
@@ -707,7 +707,7 @@
               class="control-btn"
               id="pwa-install-control"
               title="Install App"
-              aria-label="Install OpenClaw"
+              aria-label="Install Captain Claw"
               style="display: none"
             >
               <svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
@@ -729,10 +729,10 @@
       <div class="onboard-card">
         <div class="onboard-emoji">🎮</div>
         <span id="installBadge" class="onboard-badge">&nbsp;</span>
-        <h2>Install OpenClaw?</h2>
-        <p id="installReason">Install OpenClaw for the best experience.</p>
+        <h2>Install Captain Claw?</h2>
+        <p id="installReason">Install Captain Claw for the best experience.</p>
         <div class="onboard-actions">
-          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install OpenClaw</button>
+          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install Captain Claw</button>
           <button class="btn btn-ghost" id="installSkipBtn">Not now</button>
         </div>
       </div>
@@ -1384,7 +1384,7 @@
           if (isIOSSafari) {
             return {
               level: 'recommended',
-              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch OpenClaw straight from your home screen.'
+              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch Captain Claw straight from your home screen.'
             };
           }
           if (isSamsungBrowser) {
@@ -1403,7 +1403,7 @@
           }
           return {
             level: 'optional',
-            reason: 'On desktop, OpenClaw already runs great in the browser. Installing simply opens it in its own dedicated window.'
+            reason: 'On desktop, Captain Claw already runs great in the browser. Installing simply opens it in its own dedicated window.'
           };
         }
 
@@ -1424,21 +1424,21 @@
           }
           if (isIOSSafari) {
             alert(
-              'Install OpenClaw on iOS:\n\n' +
+              'Install Captain Claw on iOS:\n\n' +
               '1. Tap the Share button at the bottom of Safari\n' +
               '2. Choose “Add to Home Screen”\n' +
               '3. Tap “Add” — the game launches fullscreen.'
             );
           } else if (isMacSafari) {
             alert(
-              'Install OpenClaw on Mac:\n\n' +
+              'Install Captain Claw on Mac:\n\n' +
               '1. Open the File menu in Safari\n' +
               '2. Choose “Add to Dock…”\n' +
               '3. Confirm — the game opens in its own window.'
             );
           } else {
             alert(
-              'Install OpenClaw:\n\n' +
+              'Install Captain Claw:\n\n' +
               'Open your browser menu and choose “Install app”,\n' +
               '“Add to Home Screen”, or “Create shortcut”.\n\n' +
               'The game will then open in its own fullscreen window.'
@@ -1461,7 +1461,7 @@
         }
 
         // Public API for the onboarding flow (game-init.js).
-        window.OpenClawInstall = {
+        window.CaptainClawWebInstall = {
           isInstalled: isStandalone,
           platform: {
             isIOSSafari: isIOSSafari,
@@ -1495,13 +1495,13 @@
         window.startLoadWatchdog = function () {
           if (watchdog || shown) return;
           watchdog = setTimeout(function () {
-            if (!window.__openClawRunning) window.showLoadError();
+            if (!window.__captainClawWebRunning) window.showLoadError();
           }, 20000);
         };
         // The game sets this once it is actually rendering (postRun); if that
         // never happens, the watchdog fires.
         window.markGameRunning = function () {
-          window.__openClawRunning = true;
+          window.__captainClawWebRunning = true;
           if (watchdog) { clearTimeout(watchdog); watchdog = null; }
         };
 
@@ -1514,7 +1514,7 @@
         // runtime errors (e.g. Vite's HMR websocket) or post-boot glitches.
         var BOOT_FAIL = /ASM_CONSTS|null function|RuntimeError|abort\(|table index is out of bounds|memory access out of bounds/i;
         function maybeBootFailure(msg) {
-          if (window.__openClawRunning || shown) return;
+          if (window.__captainClawWebRunning || shown) return;
           if (msg && BOOT_FAIL.test(String(msg))) window.showLoadError();
         }
         window.addEventListener('error', function (e) {
@@ -1544,7 +1544,7 @@
          marker. Both are defer-safe (they act on window 'load' or at end of
          parse), so external + defer is fine. The localStorage-isolation shim
          stays INLINE in <head> because it must patch Storage.prototype before
-         any other script (incl. the save glue baked into openclaw.js) runs. -->
+         any other script (incl. the save glue baked into captain-claw-web.js) runs. -->
     <script src="sw-register.js" defer></script>
     <script src="env-marker.js" defer></script>
   </body>

--- a/Build_Release/env-marker.js
+++ b/Build_Release/env-marker.js
@@ -5,7 +5,7 @@
 (function () {
   var m = location.pathname.match(/\/staging\//);
   var env = m ? 'staging' : 'production';
-  console.info('[env] Captain Claw environment: ' + env + ' (' + location.pathname + ')');
+  console.info('[env] Captain Claw Web environment: ' + env + ' (' + location.pathname + ')');
   if (env === 'production') return;
   window.addEventListener('load', function () {
     var b = document.createElement('div');

--- a/Build_Release/env-marker.js
+++ b/Build_Release/env-marker.js
@@ -5,7 +5,7 @@
 (function () {
   var m = location.pathname.match(/\/staging\//);
   var env = m ? 'staging' : 'production';
-  console.info('[env] OpenClaw environment: ' + env + ' (' + location.pathname + ')');
+  console.info('[env] Captain Claw environment: ' + env + ' (' + location.pathname + ')');
   if (env === 'production') return;
   window.addEventListener('load', function () {
     var b = document.createElement('div');

--- a/Build_Release/game-init.js
+++ b/Build_Release/game-init.js
@@ -1,5 +1,5 @@
 /**
- * Main ES Module Coordinator for OpenClaw
+ * Main ES Module Coordinator for Captain Claw
  * Imports all modules and exposes necessary functions to window for HTML compatibility
  */
 
@@ -81,7 +81,7 @@ async function checkClawRezCached() {
 // when the user chooses Install or Not now (or immediately if not applicable).
 function runInstallOnboarding() {
   return new Promise((resolve) => {
-    var api = window.OpenClawInstall;
+    var api = window.CaptainClawWebInstall;
     var screen = document.getElementById('installScreen');
     var SEEN_KEY = 'pwa_install_onboarded';
 
@@ -140,7 +140,7 @@ window.initGameWhenReady = async function() {
       // Small delay to ensure all async operations are complete
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // loadGame() is defined in inline script and handles openclaw.js injection
+      // loadGame() is defined in inline script and handles captain-claw-web.js injection
       if (typeof window.loadGame === 'function') {
         window.loadGame();
       } else {

--- a/Build_Release/game-init.js
+++ b/Build_Release/game-init.js
@@ -140,7 +140,7 @@ window.initGameWhenReady = async function() {
       // Small delay to ensure all async operations are complete
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      // loadGame() is defined in inline script and handles captain-claw-web.js injection
+      // loadGame() is defined in inline script and handles openclaw.js injection
       if (typeof window.loadGame === 'function') {
         window.loadGame();
       } else {

--- a/Build_Release/game-init.js
+++ b/Build_Release/game-init.js
@@ -1,5 +1,5 @@
 /**
- * Main ES Module Coordinator for Captain Claw
+ * Main ES Module Coordinator for Captain Claw Web
  * Imports all modules and exposes necessary functions to window for HTML compatibility
  */
 

--- a/Build_Release/gamepad-bridge.js
+++ b/Build_Release/gamepad-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Gamepad Bridge for Captain Claw WASM
+ * Gamepad Bridge for Captain Claw Web
  *
  * Behavior changes based on game state:
  * - Menu/Paused: Simulate keyboard for navigation (single press)

--- a/Build_Release/gamepad-bridge.js
+++ b/Build_Release/gamepad-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Gamepad Bridge for OpenClaw WASM
+ * Gamepad Bridge for Captain Claw WASM
  *
  * Behavior changes based on game state:
  * - Menu/Paused: Simulate keyboard for navigation (single press)

--- a/Build_Release/keyboard-capture.js
+++ b/Build_Release/keyboard-capture.js
@@ -1,5 +1,5 @@
 /**
- * Keyboard Capture for OpenClaw WASM
+ * Keyboard Capture for Captain Claw WASM
  *
  * Prevents browser/OS shortcuts from interfering with game controls.
  * - Blocks Ctrl/Cmd + common shortcuts when game is focused

--- a/Build_Release/keyboard-capture.js
+++ b/Build_Release/keyboard-capture.js
@@ -1,5 +1,5 @@
 /**
- * Keyboard Capture for Captain Claw WASM
+ * Keyboard Capture for Captain Claw Web
  *
  * Prevents browser/OS shortcuts from interfering with game controls.
  * - Blocks Ctrl/Cmd + common shortcuts when game is focused

--- a/Build_Release/pointer-bridge.js
+++ b/Build_Release/pointer-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Pointer Events Bridge for OpenClaw WASM
+ * Pointer Events Bridge for Captain Claw WASM
  *
  * Single modern input path for mouse, touch and pen. Listens to the browser's
  * Pointer Events API on the canvas and forwards each event to C++ via the

--- a/Build_Release/pointer-bridge.js
+++ b/Build_Release/pointer-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Pointer Events Bridge for Captain Claw WASM
+ * Pointer Events Bridge for Captain Claw Web
  *
  * Single modern input path for mouse, touch and pen. Listens to the browser's
  * Pointer Events API on the canvas and forwards each event to C++ via the

--- a/Build_Release/save-storage.js
+++ b/Build_Release/save-storage.js
@@ -1,11 +1,11 @@
 /**
  * Save data export/import helpers (called from C++ via EM_ASM)
- * Save progress is stored in localStorage under 'openclaw:saves'.
+ * Save progress is stored in localStorage under 'captain-claw-web:saves'.
  */
 
 window.exportSaveData = function() {
   try {
-    var jsonStr = localStorage.getItem('openclaw:saves');
+    var jsonStr = localStorage.getItem('captain-claw-web:saves');
     if (!jsonStr) {
       console.warn('[SaveStorage] No save data to export');
       return;
@@ -14,7 +14,7 @@ window.exportSaveData = function() {
     var url = URL.createObjectURL(blob);
     var a = document.createElement('a');
     a.href = url;
-    a.download = 'openclaw_save.json';
+    a.download = 'captain-claw-web_save.json';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -40,7 +40,7 @@ window.importSaveData = function() {
       reader.onload = function(ev) {
         try {
           JSON.parse(ev.target.result);
-          localStorage.setItem('openclaw:saves', ev.target.result);
+          localStorage.setItem('captain-claw-web:saves', ev.target.result);
           console.log('[SaveStorage] Save data imported');
           if (Module && Module._OnJSSaveDataImported) {
             Module._OnJSSaveDataImported();

--- a/Build_Release/site.webmanifest
+++ b/Build_Release/site.webmanifest
@@ -1,8 +1,8 @@
 {
-  "name": "OpenClaw",
-  "short_name": "OpenClaw",
+  "name": "Captain Claw Web",
+  "short_name": "Captain Claw Web",
   "description": "Captain Claw (1997) platformer reimplementation",
-  "start_url": "./openclaw.html",
+  "start_url": "./captain-claw-web.html",
   "display": "fullscreen",
   "orientation": "landscape",
   "background_color": "#000000",

--- a/Build_Release/sw-register.js
+++ b/Build_Release/sw-register.js
@@ -26,9 +26,9 @@
         // unscoped clear would unregister production's SW and delete its
         // caches when only staging's switch was flipped. We match our own
         // scope path (the page's directory) for registrations and the sw.js
-        // cache-name convention ("openclaw::<scope>::") for caches.
+        // cache-name convention ("captain-claw-web::<scope>::") for caches.
         var scopeDir = location.pathname.replace(/[^/]*$/, '');
-        var cachePrefix = 'openclaw::' + scopeDir + '::';
+        var cachePrefix = 'captain-claw-web::' + scopeDir + '::';
         return navigator.serviceWorker.getRegistrations()
           .then(function (regs) {
             return Promise.all(regs

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -2,8 +2,8 @@
 // Vite will serve these with consistent, deterministic paths
 
 // Self-scope the cache name to this SW's own directory so multiple
-// deployments sharing one origin (e.g. production at /WASM-Captain Claw/ and
-// staging at /WASM-Captain Claw/staging/) get DISTINCT caches. Without this they
+// deployments sharing one origin (e.g. production at /captain-claw-web/ and
+// staging at /captain-claw-web/staging/) get DISTINCT caches. Without this they
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -2,8 +2,8 @@
 // Vite will serve these with consistent, deterministic paths
 
 // Self-scope the cache name to this SW's own directory so multiple
-// deployments sharing one origin (e.g. production at /WASM-OpenClaw/ and
-// staging at /WASM-OpenClaw/staging/) get DISTINCT caches. Without this they
+// deployments sharing one origin (e.g. production at /WASM-Captain Claw/ and
+// staging at /WASM-Captain Claw/staging/) get DISTINCT caches. Without this they
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.
@@ -15,13 +15,13 @@ const SCOPE_PATH = (function () {
     return self.location.pathname.replace(/[^/]*$/, ""); // strip "sw.js"
   }
 })();
-const CACHE_PREFIX = "openclaw::" + SCOPE_PATH + "::";
+const CACHE_PREFIX = "captain-claw-web::" + SCOPE_PATH + "::";
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
 // Essential assets needed to boot the game
 // These are served by Vite and have stable, hashed filenames in production
 const SHELL_ASSETS = [
-  "./openclaw.html",
+  "./captain-claw-web.html",
   "./game-init.js",
   "./asset-storage.js",
   "./asset-loader.js",
@@ -60,7 +60,7 @@ self.addEventListener("install", (event) => {
 
 // On activate: prune only THIS scope's stale caches. We must never delete a
 // sibling deployment's cache, so we only touch keys under our own CACHE_PREFIX
-// (plus the legacy pre-scoping "openclaw-*" names). Legacy caches are only
+// (plus the legacy pre-scoping "captain-claw-web-*" names). Legacy caches are only
 // reclaimed by non-staging scopes: production created them before scoping
 // existed, and staging never ran the old scheme, so staging must leave them
 // for production to clean up.
@@ -75,7 +75,7 @@ self.addEventListener("activate", (event) => {
             .filter((k) => {
               if (k === CACHE_NAME) return false; // keep current
               var ours = k.indexOf(CACHE_PREFIX) === 0;
-              var legacy = /^openclaw-/.test(k) && !IS_STAGING;
+              var legacy = /^captain-claw-web-/.test(k) && !IS_STAGING;
               return ours || legacy;
             })
             .map((k) => {

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -1,5 +1,5 @@
 /**
- * On-screen touch controls (joystick + action buttons) for Captain Claw WASM.
+ * On-screen touch controls (joystick + action buttons) for Captain Claw Web.
  *
  * Renders an HTML/CSS overlay on top of the canvas and drives the game by
  * dispatching KeyboardEvents on the window — the same input path the engine's

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -1,5 +1,5 @@
 /**
- * On-screen touch controls (joystick + action buttons) for OpenClaw WASM.
+ * On-screen touch controls (joystick + action buttons) for Captain Claw WASM.
  *
  * Renders an HTML/CSS overlay on top of the canvas and drives the game by
  * dispatching KeyboardEvents on the window — the same input path the engine's
@@ -557,7 +557,7 @@
 
   // ---- Movement mode toggle (joystick <-> d-pad) ----------------------------
 
-  var MOVE_STORAGE_KEY = "openclaw.touchMoveMode";
+  var MOVE_STORAGE_KEY = "captain-claw-web.touchMoveMode";
   function loadMoveMode() {
     try {
       var v = localStorage.getItem(MOVE_STORAGE_KEY);
@@ -591,11 +591,11 @@
   }
 
   // ---- Install button -------------------------------------------------------
-  // Delegates to the shared install API defined in openclaw.html. Removed from
+  // Delegates to the shared install API defined in captain-claw-web.html. Removed from
   // the DOM if the app is already installed or no install path exists.
   function setupInstallButton(el) {
     if (!el) return;
-    var api = window.OpenClawInstall;
+    var api = window.CaptainClawWebInstall;
     if (!api || api.isInstalled) {
       el.remove();
       return;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Guidance for Claude Code when working in this repository.
 
-> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/captain-claw-web`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/OpenClaw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/captain-claw-web`.
+> **Repository:** all pushes, branches, PRs, and deploys go to `arthurboss/captain-claw-web`. When using `gh`, pass `--repo arthurboss/captain-claw-web`.
 
 ## Overview
 
@@ -132,4 +132,4 @@ Emscripten flags live in `CMakeLists.txt` (SDL2 + image/ttf/gfx/mixer, `ASYNCIFY
 ## Docs & References
 
 - `docs/` — player (`GAMEPAD.md`, `TROUBLESHOOTING.md`), developer (`BUILDING.md`, `ARCHITECTURE.md`, `SAVE_SYSTEM.md`, `HAPTIC_FEEDBACK.md`, `SCREEN_RENDERING.md`, `GENERIC_GRAPHICS.md`).
-- Original Captain Claw: <https://github.com/pjasicek/OpenClaw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>
+- Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 Guidance for Claude Code when working in this repository.
 
-> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/WASM-OpenClaw`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/OpenClaw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/WASM-OpenClaw`.
+> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/WASM-Captain Claw`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/Captain Claw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/WASM-Captain Claw`.
 
 ## Overview
 
-OpenClaw WASM is a browser-based fork of Captain Claw (1997), focused on optimizing the WebAssembly build. The original archive (`CLAW.REZ`, ~113MB) is **not** bundled: the user uploads it once and it's stored compressed in IndexedDB. Startup is fast (~48MB download, 2-3s) because level assets lazy-load on demand.
+Captain Claw WASM is a browser-based fork of Captain Claw (1997), focused on optimizing the WebAssembly build. The original archive (`CLAW.REZ`, ~113MB) is **not** bundled: the user uploads it once and it's stored compressed in IndexedDB. Startup is fast (~48MB download, 2-3s) because level assets lazy-load on demand.
 
 ## Prerequisites
 
@@ -32,21 +32,21 @@ rm -rf build && ./build_wasm.sh   # clean build
 yarn dev                 # Vite at http://localhost:5173/
 ```
 
-Vite gives hot reload and rewrites `/` → `/openclaw.html`. Serve over `localhost` (a **secure context**), which Keyboard Lock and Web Audio / AudioWorklet require; a plain-HTTP LAN IP breaks those APIs.
+Vite gives hot reload and rewrites `/` → `/captain-claw-web.html``. Serve over `localhost` (a **secure context**), which Keyboard Lock and Web Audio / AudioWorklet require; a plain-HTTP LAN IP breaks those APIs.
 
 ## Deployment (GitHub Pages)
 
 Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
 
-- **Production:** <https://arthurboss.github.io/WASM-OpenClaw/> — `./scripts/deploy-prod.sh ["msg"]`
-- **Staging:** <https://arthurboss.github.io/WASM-OpenClaw/staging/> — `./scripts/deploy-staging.sh ["msg"]`
+- **Production:** <https://arthurboss.github.io/WASM-Captain Claw/> — `./scripts/deploy-prod.sh ["msg"]`
+- **Staging:** <https://arthurboss.github.io/WASM-Captain Claw/staging/> — `./scripts/deploy-staging.sh ["msg"]`
 
 **Default workflow:** deploy every new branch to **staging first** (safe — never touches prod), test on a real device, then merge and run `deploy-prod.sh` to promote. Skip only for deploy-only/non-visual changes.
 
 **Env isolation** (prod + staging share one origin, so storage is scoped deliberately):
 
 - **SW cache** named per scope (`openclaw::<scope>::<version>`) — a version bump in one env can't delete the other's cache; kill-switch teardown is scoped too.
-- **`localStorage`** namespaced by scope: prod keeps bare keys (preserves existing saves), `/staging/` gets a `staging:` prefix. A `Storage.prototype` shim inlined in `<head>` does this — it **must** stay inline (runs before the save glue baked into `openclaw.js`), unlike the external `sw-register.js` / `env-marker.js`.
+- **`localStorage`** namespaced by scope: prod keeps bare keys (preserves existing saves), `/staging/` gets a `staging:` prefix. A `Storage.prototype` shim inlined in `<head>` does this — it **must** stay inline (runs before the save glue baked into the WASM runtime), unlike the external `sw-register.js` / `env-marker.js`.
 - **`IndexedDB`** (`CLAW.REZ` + assets) is intentionally **shared** — staging needs no re-upload.
 - Gold **STAGING** badge marks non-production builds.
 
@@ -55,7 +55,7 @@ Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch
 ### Layout
 
 ```text
-OpenClaw/Engine/       # Core C++ engine
+Captain Claw/Engine/       # Core C++ engine
   Actor/ Audio/ Events/ GameApp/ Physics/ Resource/ Scene/ UserInterface/ Process/ Logger/ Util/
   Graphics/WASM/       # WebGL renderer (Graphics/Generic/ = platform-agnostic abstraction)
 libwap/ Box2D/ ThirdParty/     # WAP parser, physics, deps (TinyXML, FastDelegate, sigc++)
@@ -132,4 +132,4 @@ Emscripten flags live in `CMakeLists.txt` (SDL2 + image/ttf/gfx/mixer, `ASYNCIFY
 ## Docs & References
 
 - `docs/` — player (`GAMEPAD.md`, `TROUBLESHOOTING.md`), developer (`BUILDING.md`, `ARCHITECTURE.md`, `SAVE_SYSTEM.md`, `HAPTIC_FEEDBACK.md`, `SCREEN_RENDERING.md`, `GENERIC_GRAPHICS.md`).
-- Original OpenClaw: <https://github.com/pjasicek/OpenClaw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>
+- Original Captain Claw: <https://github.com/pjasicek/Captain Claw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ Vite gives hot reload and rewrites `/` → `/captain-claw-web.html``. Serve over
 
 Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
 
-- **Production:** <https://arthurboss.github.io/WASM-Captain Claw/> — `./scripts/deploy-prod.sh ["msg"]`
-- **Staging:** <https://arthurboss.github.io/WASM-Captain Claw/staging/> — `./scripts/deploy-staging.sh ["msg"]`
+- **Production:** <https://arthurboss.github.io/captain-claw-web/> — `./scripts/deploy-prod.sh ["msg"]`
+- **Staging:** <https://arthurboss.github.io/captain-claw-web/staging/> — `./scripts/deploy-staging.sh ["msg"]`
 
 **Default workflow:** deploy every new branch to **staging first** (safe — never touches prod), test on a real device, then merge and run `deploy-prod.sh` to promote. Skip only for deploy-only/non-visual changes.
 
@@ -55,7 +55,7 @@ Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch
 ### Layout
 
 ```text
-Captain Claw/Engine/       # Core C++ engine
+OpenClaw/Engine/       # Core C++ engine
   Actor/ Audio/ Events/ GameApp/ Physics/ Resource/ Scene/ UserInterface/ Process/ Logger/ Util/
   Graphics/WASM/       # WebGL renderer (Graphics/Generic/ = platform-agnostic abstraction)
 libwap/ Box2D/ ThirdParty/     # WAP parser, physics, deps (TinyXML, FastDelegate, sigc++)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Guidance for Claude Code when working in this repository.
 
-> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/WASM-Captain Claw`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/Captain Claw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/WASM-Captain Claw`.
+> **Never touch the upstream / original repository.** This is a fork. All pushes, branches, PRs, and deploys go to the fork (`arthurboss/captain-claw-web`) only. Never push to, open PRs against, or otherwise modify upstream (`pjasicek/OpenClaw`); it is read-only reference. When using `gh`, always pass `--repo arthurboss/captain-claw-web`.
 
 ## Overview
 
@@ -132,4 +132,4 @@ Emscripten flags live in `CMakeLists.txt` (SDL2 + image/ttf/gfx/mixer, `ASYNCIFY
 ## Docs & References
 
 - `docs/` — player (`GAMEPAD.md`, `TROUBLESHOOTING.md`), developer (`BUILDING.md`, `ARCHITECTURE.md`, `SAVE_SYSTEM.md`, `HAPTIC_FEEDBACK.md`, `SCREEN_RENDERING.md`, `GENERIC_GRAPHICS.md`).
-- Original Captain Claw: <https://github.com/pjasicek/Captain Claw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>
+- Original Captain Claw: <https://github.com/pjasicek/OpenClaw> · Emscripten: <https://emscripten.org/docs/> · SDL2: <https://wiki.libsdl.org/>

--- a/OpenClaw/ClawGameApp.h
+++ b/OpenClaw/ClawGameApp.h
@@ -5,7 +5,7 @@
 class ClawGameApp : public BaseGameApp
 {
 public:
-    virtual const char* VGetGameTitle() { return "Captain Claw"; }
+    virtual const char* VGetGameTitle() { return "Captain Claw Web"; }
     virtual const char* VGetGameAppDirectory() { return SDL_GetBasePath(); }
     virtual BaseGameLogic* VCreateGameAndView();
 };

--- a/OpenClaw/Engine/GameApp/SaveBridge.cpp
+++ b/OpenClaw/Engine/GameApp/SaveBridge.cpp
@@ -14,7 +14,7 @@ namespace SaveBridge {
 bool SaveToIndexedDB(const std::string& jsonData) {
     int result = EM_ASM_INT({
         try {
-            localStorage.setItem('openclaw:saves', UTF8ToString($0));
+            localStorage.setItem('captain-claw-web:saves', UTF8ToString($0));
             return 1;
         } catch (e) {
             console.error('[SaveBridge] Save error:', e);
@@ -28,7 +28,7 @@ bool SaveToIndexedDB(const std::string& jsonData) {
 std::string LoadFromIndexedDB() {
     char* result = (char*)EM_ASM_INT({
         try {
-            var jsonStr = localStorage.getItem('openclaw:saves');
+            var jsonStr = localStorage.getItem('captain-claw-web:saves');
             if (!jsonStr) return 0;
             var lengthBytes = lengthBytesUTF8(jsonStr) + 1;
             var ptr = _malloc(lengthBytes);
@@ -52,7 +52,7 @@ std::string LoadFromIndexedDB() {
 bool HasSaveData() {
     int result = EM_ASM_INT({
         try {
-            return localStorage.getItem('openclaw:saves') ? 1 : 0;
+            return localStorage.getItem('captain-claw-web:saves') ? 1 : 0;
         } catch (e) {
             return 0;
         }
@@ -64,7 +64,7 @@ bool HasSaveData() {
 bool DeleteSaveData() {
     int result = EM_ASM_INT({
         try {
-            localStorage.removeItem('openclaw:saves');
+            localStorage.removeItem('captain-claw-web:saves');
             return 1;
         } catch (e) {
             console.error('[SaveBridge] Delete error:', e);

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ Original game assets (CLAW.REZ) remain copyright Monolith Productions.
 ## Credits
 
 - **Original Game:** Monolith Productions (1997)
-- **OpenClaw Engine:** [pjasicek](https://github.com/pjasicek/OpenClaw)
+- **OpenClaw Engine:** pjasicek
 - **WASM Port:** Arthur Boss
 
 ---
 
-**Note:** This is a WASM-only fork optimized for browsers. For native desktop builds, visit the [original OpenClaw repository](https://github.com/pjasicek/OpenClaw).
+**Note:** This is a WASM-only port optimized for browsers.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Play Captain Claw (1997) in your web browser - no installation needed!
 
-> **⚠️ URL Changed:** This project was renamed from `WASM-OpenClaw`. If you have an old bookmark to `/WASM-OpenClaw/`, it will 404. Update to [https://arthurboss.github.io/captain-claw-web/](https://arthurboss.github.io/captain-claw-web/). Note: Game saves and cached assets are stored per-URL, so you will need to re-upload your `CLAW.REZ` file.
+> **⚠️ URL Changed:** This project was renamed from `WASM-OpenClaw`. Old bookmarks to `/WASM-OpenClaw/` will redirect, but please update to [https://arthurboss.github.io/captain-claw-web/](https://arthurboss.github.io/captain-claw-web/). Your uploaded `CLAW.REZ` and saved progress are preserved automatically (they are stored per-origin and migrated on first load) — no re-upload needed.
 
 **Play [here](https://arthurboss.github.io/captain-claw-web/)** (requires you to upload the CLAW.REZ file)
 
@@ -28,8 +28,8 @@ Browser-based version of the classic platformer. Based on [OpenClaw](https://git
 1. **Clone or download the repository:**
 
    ```bash
-   git clone https://github.com/arthurboss/WASM-OpenClaw.git
-   cd WASM-OpenClaw
+   git clone https://github.com/arthurboss/captain-claw-web.git
+   cd captain-claw-web
    ```
 
 2. **Build the game:**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# OpenClaw WASM
+# Captain Claw Web
 
 > Play Captain Claw (1997) in your web browser - no installation needed!
 
-**Play [here](https://arthurboss.github.io/WASM-OpenClaw/)** (requires you to upload the CLAW.REZ file)
+> **⚠️ URL Changed:** This project was renamed from `WASM-OpenClaw`. If you have an old bookmark to `/WASM-OpenClaw/`, it will 404. Update to [https://arthurboss.github.io/captain-claw-web/](https://arthurboss.github.io/captain-claw-web/). Note: Game saves and cached assets are stored per-URL, so you will need to re-upload your `CLAW.REZ` file.
+
+**Play [here](https://arthurboss.github.io/captain-claw-web/)** (requires you to upload the CLAW.REZ file)
 
 Browser-based version of the classic platformer. Based on [OpenClaw](https://github.com/pjasicek/OpenClaw) by pjasicek.
 
@@ -17,7 +19,6 @@ Browser-based version of the classic platformer. Based on [OpenClaw](https://git
 ## Quick Start
 
 ### Requirements
-
 - **Browser:** Chrome 105+ / Firefox 121+ / Safari 16.4+ / Edge 105+
 - **Storage:** ~120MB free space in browser
 - **CLAW.REZ:** Original game assets from Captain Claw (1997) — you must own the game

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -332,6 +332,5 @@ Potential improvements for even better performance:
 
 ## References
 
-- Original Captain Claw: <https://github.com/pjasicek/OpenClaw>
 - Emscripten Documentation: <https://emscripten.org/docs/>
 - IndexedDB API: <https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API>

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# OpenClaw WASM Architecture
+# Captain Claw WASM Architecture
 
 ## Overview
 
-OpenClaw WASM uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
+Captain Claw WASM uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
 
 ## Asset Loading Strategy
 
@@ -190,7 +190,7 @@ Build_Release/
 ├─ openclaw.wasm        # Compiled game code (~48MB)
 ├─ openclaw.js          # Emscripten runtime loader (~413KB)
 ├─ openclaw.data        # Preloaded assets
-├─ openclaw.html        # Game entry point
+├─ captain-claw-web.html        # Game entry point
 ├─ *.js                 # Bridge modules (graphics, textures, asset loading)
 └─ config.xml           # Game configuration
 ```
@@ -269,13 +269,13 @@ INFO: Level assets loaded for LEVEL2
 
 ### Lazy Loading Implementation
 
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:173` - Startup (skips eager metadata load)
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1356` - `LoadSingleLevelMetadata()`
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1545` - `GetLevelMetadata()` (with lazy load)
+- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:173` - Startup (skips eager metadata load)
+- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:1356` - `LoadSingleLevelMetadata()`
+- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:1545` - `GetLevelMetadata()` (with lazy load)
 
 ### Resource Cache System
 
-- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:186-196` - VPreload calls (startup assets)
+- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:186-196` - VPreload calls (startup assets)
 - Resource cache system (default 150 items, configurable in config.xml)
 
 ### Asset Loading Implementation
@@ -332,6 +332,6 @@ Potential improvements for even better performance:
 
 ## References
 
-- Original OpenClaw: <https://github.com/pjasicek/OpenClaw>
+- Original Captain Claw: <https://github.com/pjasicek/Captain Claw>
 - Emscripten Documentation: <https://emscripten.org/docs/>
 - IndexedDB API: <https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API>

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -269,13 +269,13 @@ INFO: Level assets loaded for LEVEL2
 
 ### Lazy Loading Implementation
 
-- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:173` - Startup (skips eager metadata load)
-- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:1356` - `LoadSingleLevelMetadata()`
-- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:1545` - `GetLevelMetadata()` (with lazy load)
+- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:173` - Startup (skips eager metadata load)
+- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1356` - `LoadSingleLevelMetadata()`
+- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:1545` - `GetLevelMetadata()` (with lazy load)
 
 ### Resource Cache System
 
-- `Captain Claw/Engine/GameApp/BaseGameApp.cpp:186-196` - VPreload calls (startup assets)
+- `OpenClaw/Engine/GameApp/BaseGameApp.cpp:186-196` - VPreload calls (startup assets)
 - Resource cache system (default 150 items, configurable in config.xml)
 
 ### Asset Loading Implementation

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# Captain Claw WASM Architecture
+# Captain Claw Web Architecture
 
 ## Overview
 
-Captain Claw WASM uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
+Captain Claw Web uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
 
 ## Asset Loading Strategy
 
@@ -332,6 +332,6 @@ Potential improvements for even better performance:
 
 ## References
 
-- Original Captain Claw: <https://github.com/pjasicek/Captain Claw>
+- Original Captain Claw: <https://github.com/pjasicek/OpenClaw>
 - Emscripten Documentation: <https://emscripten.org/docs/>
 - IndexedDB API: <https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API>

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -1,6 +1,6 @@
-# Building Captain Claw WASM
+# Building Captain Claw Web
 
-This guide covers building the WebAssembly version of Captain Claw from source.
+This guide covers building the WebAssembly version of Captain Claw Web from source.
 
 ## Prerequisites
 
@@ -42,11 +42,11 @@ source ./emsdk_env.sh
 
 **Note:** The `source ./emsdk_env.sh` command must be run in every new terminal before building.
 
-### 2. Clone Captain Claw
+### 2. Clone Captain Claw Web
 
 ```bash
 git clone [your-repo-url]
-cd Captain Claw
+cd captain-claw-web
 ```
 
 ### 3. Prepare Assets
@@ -430,4 +430,4 @@ Strip debug symbols (done by default):
 
 - Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues
 - Review Emscripten documentation: <https://emscripten.org/docs/>
-- Original Captain Claw: <https://github.com/pjasicek/Captain Claw>
+- Original Captain Claw: <https://github.com/pjasicek/OpenClaw>

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -1,6 +1,6 @@
-# Building OpenClaw WASM
+# Building Captain Claw WASM
 
-This guide covers building the WebAssembly version of OpenClaw from source.
+This guide covers building the WebAssembly version of Captain Claw from source.
 
 ## Prerequisites
 
@@ -42,11 +42,11 @@ source ./emsdk_env.sh
 
 **Note:** The `source ./emsdk_env.sh` command must be run in every new terminal before building.
 
-### 2. Clone OpenClaw
+### 2. Clone Captain Claw
 
 ```bash
 git clone [your-repo-url]
-cd OpenClaw
+cd Captain Claw
 ```
 
 ### 3. Prepare Assets
@@ -116,7 +116,7 @@ Build_Release/
 ├── openclaw.wasm       # Compiled game engine (~40MB)
 ├── openclaw.js         # Emscripten JavaScript runtime (~8MB)
 ├── openclaw.data       # Preloaded assets (ASSETS.ZIP)
-├── openclaw.html       # Game entry point
+├── captain-claw-web.html       # Game entry point
 └── *.js                # Bridge modules (graphics, textures, etc.)
 ```
 
@@ -133,7 +133,7 @@ Open: <http://localhost:5173/>
 **Features:**
 
 - Hot reload for rapid iteration
-- Clean root URL (`/` → `openclaw.html`)
+- Clean root URL (`/` → `captain-claw-web.html`)
 - No certificate warnings
 - Secure context for Keyboard Lock API and Web Audio
 
@@ -151,7 +151,7 @@ Open: <http://localhost:5173/>
 **No rebuild needed (just refresh browser):**
 
 - Modified JavaScript files (`*.js` in Build_Release/)
-- Modified HTML (`openclaw.html`)
+- Modified HTML (`captain-claw-web.html`)
 - Modified CSS styles
 - Updated documentation
 
@@ -360,13 +360,13 @@ To add custom content:
 ### File Structure
 
 ```
-OpenClaw/
+Captain Claw/
 ├── build/                      # CMake build directory (gitignored)
 ├── build_wasm.sh              # Main build script
 ├── patch_sdl2_shaders.sh      # SDL2 shader patcher
 ├── CMakeLists.txt             # Build configuration
 ├── emsdk/                     # Emscripten SDK (gitignored)
-├── OpenClaw/Engine/           # C++ source code
+├── Captain Claw/Engine/           # C++ source code
 ├── libwap/                    # Game format parser
 ├── Box2D/                     # Physics engine
 ├── ThirdParty/                # Dependencies
@@ -430,4 +430,4 @@ Strip debug symbols (done by default):
 
 - Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues
 - Review Emscripten documentation: <https://emscripten.org/docs/>
-- Original OpenClaw: <https://github.com/pjasicek/OpenClaw>
+- Original Captain Claw: <https://github.com/pjasicek/Captain Claw>

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -430,4 +430,3 @@ Strip debug symbols (done by default):
 
 - Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common issues
 - Review Emscripten documentation: <https://emscripten.org/docs/>
-- Original Captain Claw: <https://github.com/pjasicek/OpenClaw>

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -360,13 +360,13 @@ To add custom content:
 ### File Structure
 
 ```
-Captain Claw/
+OpenClaw/
 ├── build/                      # CMake build directory (gitignored)
 ├── build_wasm.sh              # Main build script
 ├── patch_sdl2_shaders.sh      # SDL2 shader patcher
 ├── CMakeLists.txt             # Build configuration
 ├── emsdk/                     # Emscripten SDK (gitignored)
-├── Captain Claw/Engine/           # C++ source code
+├── OpenClaw/Engine/           # C++ source code
 ├── libwap/                    # Game format parser
 ├── Box2D/                     # Physics engine
 ├── ThirdParty/                # Dependencies

--- a/docs/developer/HAPTIC_FEEDBACK.md
+++ b/docs/developer/HAPTIC_FEEDBACK.md
@@ -56,5 +56,5 @@ setHapticEnabled(false) // Disable haptic feedback
 ## Files
 
 - `Build_Release/gamepad-bridge.js` - JavaScript haptic functions and presets
-- `OpenClaw/Engine/GameApp/HapticFeedback.h` - C++ API
-- `OpenClaw/Engine/GameApp/HapticFeedback.cpp` - C++ implementation (calls JS via EM_ASM)
+- `Captain Claw/Engine/GameApp/HapticFeedback.h` - C++ API
+- `Captain Claw/Engine/GameApp/HapticFeedback.cpp` - C++ implementation (calls JS via EM_ASM)

--- a/docs/developer/HAPTIC_FEEDBACK.md
+++ b/docs/developer/HAPTIC_FEEDBACK.md
@@ -56,5 +56,5 @@ setHapticEnabled(false) // Disable haptic feedback
 ## Files
 
 - `Build_Release/gamepad-bridge.js` - JavaScript haptic functions and presets
-- `Captain Claw/Engine/GameApp/HapticFeedback.h` - C++ API
-- `Captain Claw/Engine/GameApp/HapticFeedback.cpp` - C++ implementation (calls JS via EM_ASM)
+- `OpenClaw/Engine/GameApp/HapticFeedback.h` - C++ API
+- `OpenClaw/Engine/GameApp/HapticFeedback.cpp` - C++ implementation (calls JS via EM_ASM)

--- a/docs/developer/SAVE_SYSTEM.md
+++ b/docs/developer/SAVE_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Captain Claw Web stores game save data in localStorage under the key `openclaw:saves``. Save data is tiny (~1-5KB JSON).
+Captain Claw Web stores game save data in localStorage under the key `captain-claw-web:saves`. Save data is tiny (~1-5KB JSON).
 
 ## Architecture
 
@@ -17,7 +17,7 @@ Captain Claw Web stores game save data in localStorage under the key `openclaw:s
 
 ### 1. SaveBridge (C++)
 
-**Files:** `Captain Claw/Engine/GameApp/SaveBridge.h`, `SaveBridge.cpp`
+**Files:** `OpenClaw/Engine/GameApp/SaveBridge.h`, `SaveBridge.cpp`
 
 C++ interface for localStorage save operations using Emscripten's `EM_ASM` macro.
 
@@ -34,7 +34,7 @@ Note: function names retain the original `IndexedDB` naming for C++ call-site co
 
 ### 2. GameSaves JSON Serialization (C++)
 
-**File:** `Captain Claw/Engine/GameApp/GameSaves.h`
+**File:** `OpenClaw/Engine/GameApp/GameSaves.h`
 
 JSON serialization methods on save structures:
 
@@ -99,14 +99,14 @@ On startup (`BaseGameLogic::Initialize()`):
 
 ```javascript
 // In browser console
-JSON.parse(localStorage.getItem('openclaw:saves'));
+JSON.parse(localStorage.getItem('captain-claw-web:saves'));
 ```
 
 ### Clearing Save Data
 
 ```javascript
 // In browser console
-localStorage.removeItem('openclaw:saves');
+localStorage.removeItem('captain-claw-web:saves');
 ```
 
 ## References

--- a/docs/developer/SAVE_SYSTEM.md
+++ b/docs/developer/SAVE_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OpenClaw stores game save data in `localStorage` under the key `openclaw:saves`. Save data is tiny (~1-5KB JSON).
+Captain Claw Web stores game save data in localStorage under the key `openclaw:saves``. Save data is tiny (~1-5KB JSON).
 
 ## Architecture
 
@@ -17,7 +17,7 @@ OpenClaw stores game save data in `localStorage` under the key `openclaw:saves`.
 
 ### 1. SaveBridge (C++)
 
-**Files:** `OpenClaw/Engine/GameApp/SaveBridge.h`, `SaveBridge.cpp`
+**Files:** `Captain Claw/Engine/GameApp/SaveBridge.h`, `SaveBridge.cpp`
 
 C++ interface for localStorage save operations using Emscripten's `EM_ASM` macro.
 
@@ -34,7 +34,7 @@ Note: function names retain the original `IndexedDB` naming for C++ call-site co
 
 ### 2. GameSaves JSON Serialization (C++)
 
-**File:** `OpenClaw/Engine/GameApp/GameSaves.h`
+**File:** `Captain Claw/Engine/GameApp/GameSaves.h`
 
 JSON serialization methods on save structures:
 

--- a/docs/developer/SCREEN_RENDERING.md
+++ b/docs/developer/SCREEN_RENDERING.md
@@ -6,7 +6,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 1. Main Menu
 - **Game State:** `GameState_Menu`
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/UserInterface.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/UserInterface.cpp`
   - `ScreenElementMenu::VOnRender()` - Main menu rendering (line ~157)
   - `ScreenElementMenuItem::VOnRender()` - Individual menu items
 - **Configuration:** `Build_Release/ASSETS/MENU.xml`
@@ -15,24 +15,24 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 2. In-Game (Gameplay)
 - **Game State:** `GameState_IngameRunning`
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/HumanView.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/HumanView.cpp`
   - `HumanView::VOnRender()` - Main render loop (line ~62)
   - Iterates through `m_ScreenElements` and renders each
-- **Scene Rendering:** `OpenClaw/Engine/Scene/Scene.cpp`
+- **Scene Rendering:** `Captain Claw/Engine/Scene/Scene.cpp`
   - `Scene::OnRender()` - Renders all scene nodes
-- **Camera:** `OpenClaw/Engine/Scene/CameraNode.cpp`
+- **Camera:** `Captain Claw/Engine/Scene/CameraNode.cpp`
   - Controls visible area, supports dynamic width for widescreen
 - **Widescreen Support:** Yes - camera width adjusts based on window aspect ratio
 
 ### 3. In-Game HUD
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/GameHUD.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/GameHUD.cpp`
   - `ScreenElementHUD` class
 - **Elements:** Score, health, lives, ammo, powerups, boss health bar
 - **Widescreen Support:** Needs verification
 
 ### 4. Quick Menu (In-Game Pause Menu)
 - **Game State:** `GameState_IngamePaused`
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/UserInterface.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/UserInterface.cpp`
   - Same `ScreenElementMenu` class as main menu
   - `m_MenuType == MenuType_IngameMenu` for pause menu specific behavior
 - **Background:** Semi-transparent overlay (game visible behind)
@@ -40,7 +40,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 5. Loading Screen (Level Load)
 - **Game State:** `GameState_LoadingLevel`
-- **Rendering Code:** `OpenClaw/Engine/GameApp/BaseGameLogic.cpp`
+- **Rendering Code:** `Captain Claw/Engine/GameApp/BaseGameLogic.cpp`
   - `RenderLoadingScreen()` function (line ~190)
 - **Background Image:** `/LEVEL{N}/SCREENS/LOADING.PCX` (per-level from CLAW.REZ)
 - **Progress Bar:** Rendered programmatically (red bar on black background)
@@ -48,7 +48,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 6. End Level Score Screen
 - **Game State:** `GameState_ScoreScreen`
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/ScoreScreen/EndLevelScoreScreen.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/ScoreScreen/EndLevelScoreScreen.cpp`
   - `ScreenElementScoreScreen::VOnRender()` (line ~368)
 - **Configuration:** `Build_Release/ASSETS/FINISHED_LEVEL_SCENES/LEVEL{N}.XML`
 - **Background Images:**
@@ -58,12 +58,12 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 7. Cutscenes
 - **Game State:** `GameState_Cutscene`
-- **Rendering Code:** `OpenClaw/Engine/Video/` directory
+- **Rendering Code:** `Captain Claw/Engine/Video/` directory
 - **Video Files:** AVI format from CLAW.REZ
 - **Widescreen Support:** Unknown - needs investigation
 
 ### 8. Console Overlay
-- **Rendering Code:** `OpenClaw/Engine/UserInterface/Console.cpp`
+- **Rendering Code:** `Captain Claw/Engine/UserInterface/Console.cpp`
   - `Console::OnRender()` (line ~641 in HumanView.cpp calls it)
 - **Activation:** Press `~` key
 - **Widescreen Support:** Renders at full window width

--- a/docs/developer/SCREEN_RENDERING.md
+++ b/docs/developer/SCREEN_RENDERING.md
@@ -6,7 +6,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 1. Main Menu
 - **Game State:** `GameState_Menu`
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/UserInterface.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/UserInterface.cpp`
   - `ScreenElementMenu::VOnRender()` - Main menu rendering (line ~157)
   - `ScreenElementMenuItem::VOnRender()` - Individual menu items
 - **Configuration:** `Build_Release/ASSETS/MENU.xml`
@@ -15,24 +15,24 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 2. In-Game (Gameplay)
 - **Game State:** `GameState_IngameRunning`
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/HumanView.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/HumanView.cpp`
   - `HumanView::VOnRender()` - Main render loop (line ~62)
   - Iterates through `m_ScreenElements` and renders each
-- **Scene Rendering:** `Captain Claw/Engine/Scene/Scene.cpp`
+- **Scene Rendering:** `OpenClaw/Engine/Scene/Scene.cpp`
   - `Scene::OnRender()` - Renders all scene nodes
-- **Camera:** `Captain Claw/Engine/Scene/CameraNode.cpp`
+- **Camera:** `OpenClaw/Engine/Scene/CameraNode.cpp`
   - Controls visible area, supports dynamic width for widescreen
 - **Widescreen Support:** Yes - camera width adjusts based on window aspect ratio
 
 ### 3. In-Game HUD
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/GameHUD.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/GameHUD.cpp`
   - `ScreenElementHUD` class
 - **Elements:** Score, health, lives, ammo, powerups, boss health bar
 - **Widescreen Support:** Needs verification
 
 ### 4. Quick Menu (In-Game Pause Menu)
 - **Game State:** `GameState_IngamePaused`
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/UserInterface.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/UserInterface.cpp`
   - Same `ScreenElementMenu` class as main menu
   - `m_MenuType == MenuType_IngameMenu` for pause menu specific behavior
 - **Background:** Semi-transparent overlay (game visible behind)
@@ -40,7 +40,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 5. Loading Screen (Level Load)
 - **Game State:** `GameState_LoadingLevel`
-- **Rendering Code:** `Captain Claw/Engine/GameApp/BaseGameLogic.cpp`
+- **Rendering Code:** `OpenClaw/Engine/GameApp/BaseGameLogic.cpp`
   - `RenderLoadingScreen()` function (line ~190)
 - **Background Image:** `/LEVEL{N}/SCREENS/LOADING.PCX` (per-level from CLAW.REZ)
 - **Progress Bar:** Rendered programmatically (red bar on black background)
@@ -48,7 +48,7 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 6. End Level Score Screen
 - **Game State:** `GameState_ScoreScreen`
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/ScoreScreen/EndLevelScoreScreen.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/ScoreScreen/EndLevelScoreScreen.cpp`
   - `ScreenElementScoreScreen::VOnRender()` (line ~368)
 - **Configuration:** `Build_Release/ASSETS/FINISHED_LEVEL_SCENES/LEVEL{N}.XML`
 - **Background Images:**
@@ -58,12 +58,12 @@ This document maps the various game screens to their rendering code locations. S
 
 ### 7. Cutscenes
 - **Game State:** `GameState_Cutscene`
-- **Rendering Code:** `Captain Claw/Engine/Video/` directory
+- **Rendering Code:** `OpenClaw/Engine/Video/` directory
 - **Video Files:** AVI format from CLAW.REZ
 - **Widescreen Support:** Unknown - needs investigation
 
 ### 8. Console Overlay
-- **Rendering Code:** `Captain Claw/Engine/UserInterface/Console.cpp`
+- **Rendering Code:** `OpenClaw/Engine/UserInterface/Console.cpp`
   - `Console::OnRender()` (line ~641 in HumanView.cpp calls it)
 - **Activation:** Press `~` key
 - **Widescreen Support:** Renders at full window width

--- a/docs/player/GAMEPAD.md
+++ b/docs/player/GAMEPAD.md
@@ -1,6 +1,6 @@
 # Gamepad Support
 
-OpenClaw supports Xbox, PlayStation, and most standard game controllers.
+Captain Claw supports Xbox, PlayStation, and most standard game controllers.
 
 ## Browser Support
 

--- a/docs/player/GAMEPAD.md
+++ b/docs/player/GAMEPAD.md
@@ -1,6 +1,6 @@
 # Gamepad Support
 
-Captain Claw supports Xbox, PlayStation, and most standard game controllers.
+Captain Claw Web supports Xbox, PlayStation, and most standard game controllers.
 
 ## Browser Support
 

--- a/docs/player/TROUBLESHOOTING.md
+++ b/docs/player/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Application** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **Captain ClawAssets**
+4. Right-click on **CaptainClawWebAssets**
 5. Select **Delete database**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -20,15 +20,15 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Storage** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **Captain ClawAssets**
-5. Select **Delete "Captain ClawAssets"**
+4. Right-click on **CaptainClawWebAssets**
+5. Select **Delete "CaptainClawWebAssets"**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
 **Safari:**
 
 1. Press `Option + Command + C` to open Web Inspector
 2. Go to **Storage** tab
-3. Select **IndexedDB** → **Captain ClawAssets**
+3. Select **IndexedDB** → **CaptainClawWebAssets**
 4. Click the trash icon to delete
 5. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -39,7 +39,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 3. Paste this command and press Enter:
 
    ```javascript
-   indexedDB.deleteDatabase('Captain ClawAssets')
+   indexedDB.deleteDatabase('CaptainClawWebAssets')
    ```
 
 4. Refresh the page - you'll be prompted to upload CLAW.REZ again

--- a/docs/player/TROUBLESHOOTING.md
+++ b/docs/player/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Application** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **OpenClawAssets**
+4. Right-click on **Captain ClawAssets**
 5. Select **Delete database**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -20,15 +20,15 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Storage** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **OpenClawAssets**
-5. Select **Delete "OpenClawAssets"**
+4. Right-click on **Captain ClawAssets**
+5. Select **Delete "Captain ClawAssets"**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
 **Safari:**
 
 1. Press `Option + Command + C` to open Web Inspector
 2. Go to **Storage** tab
-3. Select **IndexedDB** → **OpenClawAssets**
+3. Select **IndexedDB** → **Captain ClawAssets**
 4. Click the trash icon to delete
 5. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -39,7 +39,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 3. Paste this command and press Enter:
 
    ```javascript
-   indexedDB.deleteDatabase('OpenClawAssets')
+   indexedDB.deleteDatabase('Captain ClawAssets')
    ```
 
 4. Refresh the page - you'll be prompted to upload CLAW.REZ again
@@ -231,7 +231,7 @@ If you're running low on disk space, the game may fail to store CLAW.REZ.
 2. Try a different browser (Chrome recommended)
 3. Ensure browser is up to date
 4. Disable browser extensions temporarily
-5. Report issues at: <https://github.com/arthurboss/OpenClaw/issues>
+5. Report issues at: <https://github.com/arthurboss/Captain Claw/issues>
 
 Include in your report:
 

--- a/docs/player/TROUBLESHOOTING.md
+++ b/docs/player/TROUBLESHOOTING.md
@@ -231,7 +231,7 @@ If you're running low on disk space, the game may fail to store CLAW.REZ.
 2. Try a different browser (Chrome recommended)
 3. Ensure browser is up to date
 4. Disable browser extensions temporarily
-5. Report issues at: <https://github.com/arthurboss/Captain Claw/issues>
+5. Report issues at: <https://github.com/arthurboss/OpenClaw/issues>
 
 Include in your report:
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw",
+  "name": "captain-claw-web",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/_deploy-lib.sh
+++ b/scripts/_deploy-lib.sh
@@ -3,8 +3,8 @@
 # Sourced by deploy-prod.sh and deploy-staging.sh. Not meant to run standalone.
 #
 # gh-pages layout on origin:
-#   /            -> production (served at https://arthurboss.github.io/WASM-OpenClaw/)
-#   /staging/    -> staging    (served at .../WASM-OpenClaw/staging/)
+#   /            -> production (served at https://arthurboss.github.io/captain-claw-web/)
+#   /staging/    -> staging    (served at .../captain-claw-web/staging/)
 # Both live on the single origin/gh-pages branch. deploy-prod excludes staging/
 # from its --delete; deploy-staging scopes its rsync target to staging/ only.
 

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Deploy Build_Release/ to the ROOT of origin/gh-pages == PRODUCTION.
-#   https://arthurboss.github.io/WASM-OpenClaw/
+#   https://arthurboss.github.io/captain-claw-web/
 #
 # Safe against staging: the rsync --delete explicitly EXCLUDES staging/, so a
 # production deploy never touches the /staging/ subdirectory.
@@ -20,8 +20,8 @@ log "Syncing Build_Release/ -> gh-pages root (preserving staging/) ..."
 rsync -a --delete --exclude="staging/" "${RSYNC_EXCLUDES[@]}" \
   "$BUILD_DIR/" "$WORKTREE/"
 
-# GitHub Pages serves / from index.html; the game entry point is openclaw.html.
-cp "$BUILD_DIR/openclaw.html" "$WORKTREE/index.html"
+# GitHub Pages serves / from index.html; the game entry point is captain-claw-web.html.
+cp "$BUILD_DIR/captain-claw-web.html" "$WORKTREE/index.html"
 
 commit_and_push "$MSG"
-log "Production live at: https://arthurboss.github.io/WASM-OpenClaw/"
+log "Production live at: https://arthurboss.github.io/captain-claw-web/"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Deploy Build_Release/ to the /staging/ subdirectory of origin/gh-pages.
-#   https://arthurboss.github.io/WASM-OpenClaw/staging/
+#   https://arthurboss.github.io/captain-claw-web/staging/
 #
 # Safe against production: the rsync --delete target is scoped to the staging/
 # subdirectory only, so it can never remove or modify any root (production)
 # file. The PWA uses relative paths (manifest scope "./", SW registers with
 # scope "./"), so the staging service worker registers with scope
-# /WASM-OpenClaw/staging/ and cannot cache or interfere with production's
+# /captain-claw-web/staging/ and cannot cache or interfere with production's
 # root-scoped SW. staging/sw-control.json is its own kill-switch copy.
 #
 # Usage:  scripts/deploy-staging.sh ["commit message"]
@@ -27,7 +27,7 @@ rsync -a --delete "${RSYNC_EXCLUDES[@]}" \
   "$BUILD_DIR/" "$WORKTREE/staging/"
 
 # Entry point for /staging/ (mirrors how root uses index.html).
-cp "$BUILD_DIR/openclaw.html" "$WORKTREE/staging/index.html"
+cp "$BUILD_DIR/captain-claw-web.html" "$WORKTREE/staging/index.html"
 
 commit_and_push "$MSG"
-log "Staging live at: https://arthurboss.github.io/WASM-OpenClaw/staging/"
+log "Staging live at: https://arthurboss.github.io/captain-claw-web/staging/"

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
     outDir: resolve(import.meta.dirname, 'dist'),
     emptyOutDir: true,
     rollupOptions: {
-      input: resolve(import.meta.dirname, 'Build_Release/openclaw.html'),
+      input: resolve(import.meta.dirname, 'Build_Release/captain-claw-web.html'),
     },
     assetsInlineLimit: 0,
   },
@@ -39,7 +39,7 @@ export default defineConfig({
       name: 'rewrite-root',
       configureServer(server) {
         server.middlewares.use((req, _res, next) => {
-          if (req.url === '/') req.url = '/openclaw.html';
+          if (req.url === '/') req.url = '/captain-claw-web.html';
           next();
         });
       },


### PR DESCRIPTION
- Rename openclaw.html to captain-claw-web.html and update all references
- Update branding from OpenClaw to Captain Claw Web across docs and user-facing text
- Update GitHub Pages URLs from /WASM-OpenClaw/ to /captain-claw-web/
- Rename window object from OpenClawInstall to CaptainClawWebInstall
- Update cache/storage naming to captain-claw-web:: prefix
- Preserve upstream credit and technical identifiers (openclaw.{wasm,js,data})