### PR TITLE
refactor: rename brand to Claw Web and add fan-project disclaimer

### DIFF
--- a/Build_Release/asset-storage.js
+++ b/Build_Release/asset-storage.js
@@ -4,10 +4,12 @@
  */
 export class AssetStorage {
   constructor() {
-    this.dbName = 'CaptainClawWebAssets';
-    // Pre-rename database name. Existing users have their uploaded CLAW.REZ
-    // here; init() migrates it once so nobody has to re-upload ~113MB.
-    this.legacyDbName = 'OpenClawAssets';
+    this.dbName = 'ClawWebAssets';
+    // Pre-rename database names across rebrands, NEWEST FIRST. Existing users
+    // have their uploaded CLAW.REZ under one of these; init() migrates it once
+    // so nobody has to re-upload ~113MB, regardless of which version they came
+    // from (OpenClawAssets -> CaptainClawWebAssets -> ClawWebAssets).
+    this.legacyDbNames = ['CaptainClawWebAssets', 'OpenClawAssets'];
     this.storeName = 'files';
     this.db = null;
     this.chunkSize = 1024 * 1024 * 5; // 5MB chunks to prevent memory issues
@@ -41,11 +43,13 @@ export class AssetStorage {
   }
 
   /**
-   * One-time migration of all records from the legacy DB into the current DB.
-   * Runs only when the current DB is empty and the legacy DB has data, so it
-   * is a no-op for new users and for anyone already migrated. The legacy DB is
-   * deleted afterwards. Any failure is swallowed: migration is best-effort and
-   * must never block startup (the user can always re-upload as a fallback).
+   * One-time migration of all records from a legacy DB into the current DB.
+   * Runs only when the current DB is empty; walks legacyDbNames newest-first
+   * and migrates from the first one that holds data, so a user coming from ANY
+   * prior version keeps their upload. No-op for new users and for anyone
+   * already migrated. All prior DBs are deleted afterwards. Any failure is
+   * swallowed: migration is best-effort and must never block startup (the user
+   * can always re-upload as a fallback).
    */
   async _migrateFromLegacy() {
     try {
@@ -58,40 +62,50 @@ export class AssetStorage {
       });
       if (existing.length > 0) return;
 
-      // Does the legacy DB exist? databases() isn't in every browser, so fall
-      // back to opening it and checking for our store.
+      // If databases() is available (not in every browser), use it to skip
+      // legacy names that don't exist and avoid creating empty phantom DBs.
+      let present = null;
       if (indexedDB.databases) {
-        const dbs = await indexedDB.databases();
-        if (!dbs.some((d) => d.name === this.legacyDbName)) return;
+        try {
+          const dbs = await indexedDB.databases();
+          present = new Set(dbs.map((d) => d.name));
+        } catch (e) { present = null; }
       }
 
-      const legacy = await this._open(this.legacyDbName);
-      if (!legacy.objectStoreNames.contains(this.storeName)) {
-        legacy.close();
-        return;
-      }
+      let migrated = false;
+      for (const name of this.legacyDbNames) {
+        if (present && !present.has(name)) continue;
 
-      const records = await new Promise((resolve) => {
-        const tx = legacy.transaction([this.storeName], 'readonly');
-        const req = tx.objectStore(this.storeName).getAll();
-        req.onsuccess = (e) => resolve(e.target.result || []);
-        req.onerror = () => resolve([]);
-      });
+        const legacy = await this._open(name);
+        if (!legacy.objectStoreNames.contains(this.storeName)) {
+          legacy.close();
+          continue;
+        }
 
-      if (records.length > 0) {
-        await new Promise((resolve, reject) => {
-          const tx = this.db.transaction([this.storeName], 'readwrite');
-          const store = tx.objectStore(this.storeName);
-          records.forEach((r) => store.put(r));
-          tx.oncomplete = () => resolve();
-          tx.onerror = () => reject(tx.error);
+        const records = await new Promise((resolve) => {
+          const tx = legacy.transaction([this.storeName], 'readonly');
+          const req = tx.objectStore(this.storeName).getAll();
+          req.onsuccess = (e) => resolve(e.target.result || []);
+          req.onerror = () => resolve([]);
         });
-        console.info('[migrate] Moved ' + records.length + ' asset record(s) from ' + this.legacyDbName + '.');
-      }
+        legacy.close();
 
-      legacy.close();
-      // Remove the old DB now that its contents are safely copied.
-      indexedDB.deleteDatabase(this.legacyDbName);
+        if (!migrated && records.length > 0) {
+          await new Promise((resolve, reject) => {
+            const tx = this.db.transaction([this.storeName], 'readwrite');
+            const store = tx.objectStore(this.storeName);
+            records.forEach((r) => store.put(r));
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+          });
+          console.info('[migrate] Moved ' + records.length + ' asset record(s) from ' + name + '.');
+          migrated = true;
+        }
+
+        // Delete every legacy DB (whether or not it was the source) now that
+        // the current DB is authoritative.
+        indexedDB.deleteDatabase(name);
+      }
     } catch (e) {
       console.warn('[migrate] Legacy IndexedDB migration skipped:', e);
     }

--- a/Build_Release/claw-web.html
+++ b/Build_Release/claw-web.html
@@ -5,7 +5,7 @@
 
     <!-- Per-environment localStorage isolation. GitHub Pages serves every
          deployment from ONE origin, and localStorage is origin-scoped, so
-         production (/captain-claw-web/) and staging (/captain-claw-web/staging/)
+         production (/claw-web/) and staging (/claw-web/staging/)
          would otherwise share one key space: game saves, install-onboarding
          flag, touch-mode, and the SW kill-switch id would all collide.
          We namespace keys by scope. PRODUCTION KEEPS BARE KEYS so existing
@@ -41,39 +41,45 @@
       })();
     </script>
 
-    <!-- One-time save-data migration. The save key was renamed from the
-         pre-rebrand 'openclaw:saves' to 'captain-claw-web:saves' (matched in
-         SaveBridge.cpp). Copy an existing legacy save into the new key once so
-         returning players keep their progress, then remove the old key. Runs
-         AFTER the env shim above so the prefix (on staging) applies to both
-         keys consistently. Guarded to act only when the new key is empty and a
-         legacy value exists. -->
+    <!-- One-time save-data migration. The save key has been renamed across
+         rebrands: openclaw:saves -> captain-claw-web:saves -> claw-web:saves
+         (the current key, matched in SaveBridge.cpp). Copy a save from the most
+         recent legacy key that still holds one into the current key, so a user
+         returning from ANY prior version keeps their progress, then clear the
+         old keys. Runs AFTER the env shim above so the prefix (on staging)
+         applies to every key consistently. Guarded to act only when the current
+         key is empty. -->
     <script>
       (function () {
         try {
-          var OLD = "openclaw:saves";
-          var NEW = "captain-claw-web:saves";
+          var NEW = "claw-web:saves";
+          // Newest-first: prefer the most recent legacy key that has data.
+          var LEGACY = ["captain-claw-web:saves", "openclaw:saves"];
           if (localStorage.getItem(NEW) === null) {
-            var legacy = localStorage.getItem(OLD);
-            if (legacy !== null) {
-              localStorage.setItem(NEW, legacy);
-              localStorage.removeItem(OLD);
-              console.info("[migrate] Copied legacy save data to '" + NEW + "'.");
+            for (var i = 0; i < LEGACY.length; i++) {
+              var val = localStorage.getItem(LEGACY[i]);
+              if (val !== null) {
+                localStorage.setItem(NEW, val);
+                console.info("[migrate] Copied save data from '" + LEGACY[i] + "' to '" + NEW + "'.");
+                break;
+              }
             }
           }
+          // Clear any stale legacy keys now that the current key is authoritative.
+          for (var j = 0; j < LEGACY.length; j++) localStorage.removeItem(LEGACY[j]);
         } catch (e) {
           console.warn("[migrate] Save-data migration skipped:", e);
         }
       })();
     </script>
 
-    <title>Captain Claw Web</title>
+    <title>Claw Web</title>
     <meta
       name="description"
       content="Reimplementation of Captain Claw (1997) platformer"
     />
 
-    <meta property="og:title" content="Captain Claw Web" />
+    <meta property="og:title" content="Claw Web" />
     <meta property="og:description" content="Play Captain Claw (1997) in your web browser" />
     <!--<meta property="og:image" content="preview.png">-->
 
@@ -87,7 +93,7 @@
     <!-- iOS PWA: standalone fullscreen mode, hides Safari chrome when added to Home Screen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Captain Claw Web" />
+    <meta name="apple-mobile-web-app-title" content="Claw Web" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="theme-color" content="#000000" />
 
@@ -686,6 +692,7 @@
         </div>
 
         <p class="onboard-legal">You must own Captain Claw (1997) to use this file legally.</p>
+        <p class="onboard-legal">Unofficial fan project, not affiliated with or endorsed by the rights holders. Captain Claw is a trademark of its respective owners.</p>
       </div>
     </section>
 
@@ -734,7 +741,7 @@
               class="control-btn"
               id="pwa-install-control"
               title="Install App"
-              aria-label="Install Captain Claw Web"
+              aria-label="Install Claw Web"
               style="display: none"
             >
               <svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
@@ -756,10 +763,10 @@
       <div class="onboard-card">
         <div class="onboard-emoji">🎮</div>
         <span id="installBadge" class="onboard-badge">&nbsp;</span>
-        <h2>Install Captain Claw Web?</h2>
-        <p id="installReason">Install Captain Claw Web for the best experience.</p>
+        <h2>Install Claw Web?</h2>
+        <p id="installReason">Install Claw Web for the best experience.</p>
         <div class="onboard-actions">
-          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install Captain Claw Web</button>
+          <button class="btn btn-primary" id="installYesBtn"><svg class="icon-download" viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Install Claw Web</button>
           <button class="btn btn-ghost" id="installSkipBtn">Not now</button>
         </div>
       </div>
@@ -1411,7 +1418,7 @@
           if (isIOSSafari) {
             return {
               level: 'recommended',
-              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch Captain Claw Web straight from your home screen.'
+              reason: 'On iPhone/iPad, installing is the only way to play truly fullscreen and launch Claw Web straight from your home screen.'
             };
           }
           if (isSamsungBrowser) {
@@ -1430,7 +1437,7 @@
           }
           return {
             level: 'optional',
-            reason: 'On desktop, Captain Claw Web already runs great in the browser. Installing simply opens it in its own dedicated window.'
+            reason: 'On desktop, Claw Web already runs great in the browser. Installing simply opens it in its own dedicated window.'
           };
         }
 
@@ -1451,21 +1458,21 @@
           }
           if (isIOSSafari) {
             alert(
-              'Install Captain Claw Web on iOS:\n\n' +
+              'Install Claw Web on iOS:\n\n' +
               '1. Tap the Share button at the bottom of Safari\n' +
               '2. Choose “Add to Home Screen”\n' +
               '3. Tap “Add” — the game launches fullscreen.'
             );
           } else if (isMacSafari) {
             alert(
-              'Install Captain Claw Web on Mac:\n\n' +
+              'Install Claw Web on Mac:\n\n' +
               '1. Open the File menu in Safari\n' +
               '2. Choose “Add to Dock…”\n' +
               '3. Confirm — the game opens in its own window.'
             );
           } else {
             alert(
-              'Install Captain Claw Web:\n\n' +
+              'Install Claw Web:\n\n' +
               'Open your browser menu and choose “Install app”,\n' +
               '“Add to Home Screen”, or “Create shortcut”.\n\n' +
               'The game will then open in its own fullscreen window.'
@@ -1488,7 +1495,7 @@
         }
 
         // Public API for the onboarding flow (game-init.js).
-        window.CaptainClawWebInstall = {
+        window.ClawWebInstall = {
           isInstalled: isStandalone,
           platform: {
             isIOSSafari: isIOSSafari,

--- a/Build_Release/env-marker.js
+++ b/Build_Release/env-marker.js
@@ -5,7 +5,7 @@
 (function () {
   var m = location.pathname.match(/\/staging\//);
   var env = m ? 'staging' : 'production';
-  console.info('[env] Captain Claw Web environment: ' + env + ' (' + location.pathname + ')');
+  console.info('[env] Claw Web environment: ' + env + ' (' + location.pathname + ')');
   if (env === 'production') return;
   window.addEventListener('load', function () {
     var b = document.createElement('div');

--- a/Build_Release/game-init.js
+++ b/Build_Release/game-init.js
@@ -1,5 +1,5 @@
 /**
- * Main ES Module Coordinator for Captain Claw Web
+ * Main ES Module Coordinator for Claw Web
  * Imports all modules and exposes necessary functions to window for HTML compatibility
  */
 
@@ -81,7 +81,7 @@ async function checkClawRezCached() {
 // when the user chooses Install or Not now (or immediately if not applicable).
 function runInstallOnboarding() {
   return new Promise((resolve) => {
-    var api = window.CaptainClawWebInstall;
+    var api = window.ClawWebInstall;
     var screen = document.getElementById('installScreen');
     var SEEN_KEY = 'pwa_install_onboarded';
 

--- a/Build_Release/gamepad-bridge.js
+++ b/Build_Release/gamepad-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Gamepad Bridge for Captain Claw Web
+ * Gamepad Bridge for Claw Web
  *
  * Behavior changes based on game state:
  * - Menu/Paused: Simulate keyboard for navigation (single press)

--- a/Build_Release/keyboard-capture.js
+++ b/Build_Release/keyboard-capture.js
@@ -1,5 +1,5 @@
 /**
- * Keyboard Capture for Captain Claw Web
+ * Keyboard Capture for Claw Web
  *
  * Prevents browser/OS shortcuts from interfering with game controls.
  * - Blocks Ctrl/Cmd + common shortcuts when game is focused

--- a/Build_Release/pointer-bridge.js
+++ b/Build_Release/pointer-bridge.js
@@ -1,5 +1,5 @@
 /**
- * Pointer Events Bridge for Captain Claw Web
+ * Pointer Events Bridge for Claw Web
  *
  * Single modern input path for mouse, touch and pen. Listens to the browser's
  * Pointer Events API on the canvas and forwards each event to C++ via the

--- a/Build_Release/save-storage.js
+++ b/Build_Release/save-storage.js
@@ -1,11 +1,11 @@
 /**
  * Save data export/import helpers (called from C++ via EM_ASM)
- * Save progress is stored in localStorage under 'captain-claw-web:saves'.
+ * Save progress is stored in localStorage under 'claw-web:saves'.
  */
 
 window.exportSaveData = function() {
   try {
-    var jsonStr = localStorage.getItem('captain-claw-web:saves');
+    var jsonStr = localStorage.getItem('claw-web:saves');
     if (!jsonStr) {
       console.warn('[SaveStorage] No save data to export');
       return;
@@ -14,7 +14,7 @@ window.exportSaveData = function() {
     var url = URL.createObjectURL(blob);
     var a = document.createElement('a');
     a.href = url;
-    a.download = 'captain-claw-web_save.json';
+    a.download = 'claw-web_save.json';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -40,7 +40,7 @@ window.importSaveData = function() {
       reader.onload = function(ev) {
         try {
           JSON.parse(ev.target.result);
-          localStorage.setItem('captain-claw-web:saves', ev.target.result);
+          localStorage.setItem('claw-web:saves', ev.target.result);
           console.log('[SaveStorage] Save data imported');
           if (Module && Module._OnJSSaveDataImported) {
             Module._OnJSSaveDataImported();

--- a/Build_Release/site.webmanifest
+++ b/Build_Release/site.webmanifest
@@ -1,8 +1,8 @@
 {
-  "name": "Captain Claw Web",
-  "short_name": "Captain Claw Web",
+  "name": "Claw Web",
+  "short_name": "Claw Web",
   "description": "Captain Claw (1997) platformer reimplementation",
-  "start_url": "./captain-claw-web.html",
+  "start_url": "./claw-web.html",
   "display": "fullscreen",
   "orientation": "landscape",
   "background_color": "#000000",

--- a/Build_Release/sw-register.js
+++ b/Build_Release/sw-register.js
@@ -26,9 +26,9 @@
         // unscoped clear would unregister production's SW and delete its
         // caches when only staging's switch was flipped. We match our own
         // scope path (the page's directory) for registrations and the sw.js
-        // cache-name convention ("captain-claw-web::<scope>::") for caches.
+        // cache-name convention ("claw-web::<scope>::") for caches.
         var scopeDir = location.pathname.replace(/[^/]*$/, '');
-        var cachePrefix = 'captain-claw-web::' + scopeDir + '::';
+        var cachePrefix = 'claw-web::' + scopeDir + '::';
         return navigator.serviceWorker.getRegistrations()
           .then(function (regs) {
             return Promise.all(regs

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -2,8 +2,8 @@
 // Vite will serve these with consistent, deterministic paths
 
 // Self-scope the cache name to this SW's own directory so multiple
-// deployments sharing one origin (e.g. production at /captain-claw-web/ and
-// staging at /captain-claw-web/staging/) get DISTINCT caches. Without this they
+// deployments sharing one origin (e.g. production at /claw-web/ and
+// staging at /claw-web/staging/) get DISTINCT caches. Without this they
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.
@@ -15,13 +15,13 @@ const SCOPE_PATH = (function () {
     return self.location.pathname.replace(/[^/]*$/, ""); // strip "sw.js"
   }
 })();
-const CACHE_PREFIX = "captain-claw-web::" + SCOPE_PATH + "::";
+const CACHE_PREFIX = "claw-web::" + SCOPE_PATH + "::";
 const CACHE_NAME = CACHE_PREFIX + CACHE_VERSION;
 
 // Essential assets needed to boot the game
 // These are served by Vite and have stable, hashed filenames in production
 const SHELL_ASSETS = [
-  "./captain-claw-web.html",
+  "./claw-web.html",
   "./game-init.js",
   "./asset-storage.js",
   "./asset-loader.js",
@@ -60,7 +60,7 @@ self.addEventListener("install", (event) => {
 
 // On activate: prune only THIS scope's stale caches. We must never delete a
 // sibling deployment's cache, so we only touch keys under our own CACHE_PREFIX
-// (plus the legacy pre-scoping "captain-claw-web-*" names). Legacy caches are only
+// (plus the legacy pre-scoping "claw-web-*" names). Legacy caches are only
 // reclaimed by non-staging scopes: production created them before scoping
 // existed, and staging never ran the old scheme, so staging must leave them
 // for production to clean up.
@@ -75,7 +75,7 @@ self.addEventListener("activate", (event) => {
             .filter((k) => {
               if (k === CACHE_NAME) return false; // keep current
               var ours = k.indexOf(CACHE_PREFIX) === 0;
-              var legacy = /^captain-claw-web-/.test(k) && !IS_STAGING;
+              var legacy = /^claw-web-/.test(k) && !IS_STAGING;
               return ours || legacy;
             })
             .map((k) => {

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -7,7 +7,7 @@
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.
-const CACHE_VERSION = "v3";
+const CACHE_VERSION = "v4";
 const SCOPE_PATH = (function () {
   try {
     return new URL(self.registration.scope).pathname;

--- a/Build_Release/touch-controls.js
+++ b/Build_Release/touch-controls.js
@@ -1,5 +1,5 @@
 /**
- * On-screen touch controls (joystick + action buttons) for Captain Claw Web.
+ * On-screen touch controls (joystick + action buttons) for Claw Web.
  *
  * Renders an HTML/CSS overlay on top of the canvas and drives the game by
  * dispatching KeyboardEvents on the window — the same input path the engine's
@@ -557,7 +557,7 @@
 
   // ---- Movement mode toggle (joystick <-> d-pad) ----------------------------
 
-  var MOVE_STORAGE_KEY = "captain-claw-web.touchMoveMode";
+  var MOVE_STORAGE_KEY = "claw-web.touchMoveMode";
   function loadMoveMode() {
     try {
       var v = localStorage.getItem(MOVE_STORAGE_KEY);
@@ -591,11 +591,11 @@
   }
 
   // ---- Install button -------------------------------------------------------
-  // Delegates to the shared install API defined in captain-claw-web.html. Removed from
+  // Delegates to the shared install API defined in claw-web.html. Removed from
   // the DOM if the app is already installed or no install path exists.
   function setupInstallButton(el) {
     if (!el) return;
-    var api = window.CaptainClawWebInstall;
+    var api = window.ClawWebInstall;
     if (!api || api.isInstalled) {
       el.remove();
       return;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Guidance for Claude Code when working in this repository.
 
-> **Repository:** all pushes, branches, PRs, and deploys go to `arthurboss/captain-claw-web`. When using `gh`, pass `--repo arthurboss/captain-claw-web`.
+> **Repository:** all pushes, branches, PRs, and deploys go to `arthurboss/claw-web`. When using `gh`, pass `--repo arthurboss/claw-web`.
 
 ## Overview
 
@@ -32,14 +32,14 @@ rm -rf build && ./build_wasm.sh   # clean build
 yarn dev                 # Vite at http://localhost:5173/
 ```
 
-Vite gives hot reload and rewrites `/` → `/captain-claw-web.html``. Serve over `localhost` (a **secure context**), which Keyboard Lock and Web Audio / AudioWorklet require; a plain-HTTP LAN IP breaks those APIs.
+Vite gives hot reload and rewrites `/` → `/claw-web.html``. Serve over `localhost` (a **secure context**), which Keyboard Lock and Web Audio / AudioWorklet require; a plain-HTTP LAN IP breaks those APIs.
 
 ## Deployment (GitHub Pages)
 
 Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch: **production at root**, **staging under `/staging/`**. Neither script can clobber the other (prod excludes `staging/` from `--delete`; staging writes only `/staging/`). Both verify the WASM artifacts are fresh (guards the `ASM_CONSTS` crash from a stale loader+wasm pair) and self-clean their temp worktree.
 
-- **Production:** <https://arthurboss.github.io/captain-claw-web/> — `./scripts/deploy-prod.sh ["msg"]`
-- **Staging:** <https://arthurboss.github.io/captain-claw-web/staging/> — `./scripts/deploy-staging.sh ["msg"]`
+- **Production:** <https://arthurboss.github.io/claw-web/> — `./scripts/deploy-prod.sh ["msg"]`
+- **Staging:** <https://arthurboss.github.io/claw-web/staging/> — `./scripts/deploy-staging.sh ["msg"]`
 
 **Default workflow:** deploy every new branch to **staging first** (safe — never touches prod), test on a real device, then merge and run `deploy-prod.sh` to promote. Skip only for deploy-only/non-visual changes.
 

--- a/OpenClaw/ClawGameApp.h
+++ b/OpenClaw/ClawGameApp.h
@@ -5,7 +5,7 @@
 class ClawGameApp : public BaseGameApp
 {
 public:
-    virtual const char* VGetGameTitle() { return "Captain Claw Web"; }
+    virtual const char* VGetGameTitle() { return "Claw Web"; }
     virtual const char* VGetGameAppDirectory() { return SDL_GetBasePath(); }
     virtual BaseGameLogic* VCreateGameAndView();
 };

--- a/OpenClaw/Engine/GameApp/SaveBridge.cpp
+++ b/OpenClaw/Engine/GameApp/SaveBridge.cpp
@@ -14,7 +14,7 @@ namespace SaveBridge {
 bool SaveToIndexedDB(const std::string& jsonData) {
     int result = EM_ASM_INT({
         try {
-            localStorage.setItem('captain-claw-web:saves', UTF8ToString($0));
+            localStorage.setItem('claw-web:saves', UTF8ToString($0));
             return 1;
         } catch (e) {
             console.error('[SaveBridge] Save error:', e);
@@ -28,7 +28,7 @@ bool SaveToIndexedDB(const std::string& jsonData) {
 std::string LoadFromIndexedDB() {
     char* result = (char*)EM_ASM_INT({
         try {
-            var jsonStr = localStorage.getItem('captain-claw-web:saves');
+            var jsonStr = localStorage.getItem('claw-web:saves');
             if (!jsonStr) return 0;
             var lengthBytes = lengthBytesUTF8(jsonStr) + 1;
             var ptr = _malloc(lengthBytes);
@@ -52,7 +52,7 @@ std::string LoadFromIndexedDB() {
 bool HasSaveData() {
     int result = EM_ASM_INT({
         try {
-            return localStorage.getItem('captain-claw-web:saves') ? 1 : 0;
+            return localStorage.getItem('claw-web:saves') ? 1 : 0;
         } catch (e) {
             return 0;
         }
@@ -64,7 +64,7 @@ bool HasSaveData() {
 bool DeleteSaveData() {
     int result = EM_ASM_INT({
         try {
-            localStorage.removeItem('captain-claw-web:saves');
+            localStorage.removeItem('claw-web:saves');
             return 1;
         } catch (e) {
             console.error('[SaveBridge] Delete error:', e);

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Captain Claw Web
+# Claw Web
 
-> Play Captain Claw (1997) in your web browser - no installation needed!
+> Play the classic Claw platformer in your web browser - no installation needed!
 
-> **⚠️ URL Changed:** This project was renamed from `WASM-OpenClaw`. Old bookmarks to `/WASM-OpenClaw/` will redirect, but please update to [https://arthurboss.github.io/captain-claw-web/](https://arthurboss.github.io/captain-claw-web/). Your uploaded `CLAW.REZ` and saved progress are preserved automatically (they are stored per-origin and migrated on first load) — no re-upload needed.
+> **Unofficial fan project.** Not affiliated with, authorized, or endorsed by the rights holders. Captain Claw and its assets are trademarks/copyright of their respective owners (Monolith Productions / Warner Bros.). This project ships no game content: you supply your own `CLAW.REZ` from a copy of the game you own.
 
-**Play [here](https://arthurboss.github.io/captain-claw-web/)** (requires you to upload the CLAW.REZ file)
+> **⚠️ URL Changed:** This project was previously hosted at `/captain-claw-web/` and `/WASM-OpenClaw/`. Old bookmarks redirect, but please update to [https://arthurboss.github.io/claw-web/](https://arthurboss.github.io/claw-web/). Your uploaded `CLAW.REZ` and saved progress are preserved automatically (stored per-origin and migrated on first load) — no re-upload needed.
+
+**Play [here](https://arthurboss.github.io/claw-web/)** (requires you to upload the CLAW.REZ file)
 
 Browser-based version of the classic platformer. Based on [OpenClaw](https://github.com/pjasicek/OpenClaw) by pjasicek.
 
@@ -28,8 +30,8 @@ Browser-based version of the classic platformer. Based on [OpenClaw](https://git
 1. **Clone or download the repository:**
 
    ```bash
-   git clone https://github.com/arthurboss/captain-claw-web.git
-   cd captain-claw-web
+   git clone https://github.com/arthurboss/claw-web.git
+   cd claw-web
    ```
 
 2. **Build the game:**

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# Captain Claw Web Architecture
+# Claw Web Architecture
 
 ## Overview
 
-Captain Claw Web uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
+Claw Web uses a lazy-loading architecture optimized for browser environments. Assets are loaded on-demand rather than all at startup, significantly reducing initial load time and memory usage.
 
 ## Asset Loading Strategy
 
@@ -190,7 +190,7 @@ Build_Release/
 ├─ openclaw.wasm        # Compiled game code (~48MB)
 ├─ openclaw.js          # Emscripten runtime loader (~413KB)
 ├─ openclaw.data        # Preloaded assets
-├─ captain-claw-web.html        # Game entry point
+├─ claw-web.html        # Game entry point
 ├─ *.js                 # Bridge modules (graphics, textures, asset loading)
 └─ config.xml           # Game configuration
 ```

--- a/docs/developer/BUILDING.md
+++ b/docs/developer/BUILDING.md
@@ -1,6 +1,6 @@
-# Building Captain Claw Web
+# Building Claw Web
 
-This guide covers building the WebAssembly version of Captain Claw Web from source.
+This guide covers building the WebAssembly version of Claw Web from source.
 
 ## Prerequisites
 
@@ -42,11 +42,11 @@ source ./emsdk_env.sh
 
 **Note:** The `source ./emsdk_env.sh` command must be run in every new terminal before building.
 
-### 2. Clone Captain Claw Web
+### 2. Clone Claw Web
 
 ```bash
 git clone [your-repo-url]
-cd captain-claw-web
+cd claw-web
 ```
 
 ### 3. Prepare Assets
@@ -116,7 +116,7 @@ Build_Release/
 ├── openclaw.wasm       # Compiled game engine (~40MB)
 ├── openclaw.js         # Emscripten JavaScript runtime (~8MB)
 ├── openclaw.data       # Preloaded assets (ASSETS.ZIP)
-├── captain-claw-web.html       # Game entry point
+├── claw-web.html       # Game entry point
 └── *.js                # Bridge modules (graphics, textures, etc.)
 ```
 
@@ -133,7 +133,7 @@ Open: <http://localhost:5173/>
 **Features:**
 
 - Hot reload for rapid iteration
-- Clean root URL (`/` → `captain-claw-web.html`)
+- Clean root URL (`/` → `claw-web.html`)
 - No certificate warnings
 - Secure context for Keyboard Lock API and Web Audio
 
@@ -151,7 +151,7 @@ Open: <http://localhost:5173/>
 **No rebuild needed (just refresh browser):**
 
 - Modified JavaScript files (`*.js` in Build_Release/)
-- Modified HTML (`captain-claw-web.html`)
+- Modified HTML (`claw-web.html`)
 - Modified CSS styles
 - Updated documentation
 

--- a/docs/developer/SAVE_SYSTEM.md
+++ b/docs/developer/SAVE_SYSTEM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Captain Claw Web stores game save data in localStorage under the key `captain-claw-web:saves`. Save data is tiny (~1-5KB JSON).
+Claw Web stores game save data in localStorage under the key `claw-web:saves`. Save data is tiny (~1-5KB JSON).
 
 ## Architecture
 
@@ -99,14 +99,14 @@ On startup (`BaseGameLogic::Initialize()`):
 
 ```javascript
 // In browser console
-JSON.parse(localStorage.getItem('captain-claw-web:saves'));
+JSON.parse(localStorage.getItem('claw-web:saves'));
 ```
 
 ### Clearing Save Data
 
 ```javascript
 // In browser console
-localStorage.removeItem('captain-claw-web:saves');
+localStorage.removeItem('claw-web:saves');
 ```
 
 ## References

--- a/docs/player/GAMEPAD.md
+++ b/docs/player/GAMEPAD.md
@@ -1,6 +1,6 @@
 # Gamepad Support
 
-Captain Claw Web supports Xbox, PlayStation, and most standard game controllers.
+Claw Web supports Xbox, PlayStation, and most standard game controllers.
 
 ## Browser Support
 

--- a/docs/player/TROUBLESHOOTING.md
+++ b/docs/player/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Application** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **CaptainClawWebAssets**
+4. Right-click on **ClawWebAssets**
 5. Select **Delete database**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -20,15 +20,15 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 1. Press `F12` to open DevTools
 2. Go to **Storage** tab
 3. Expand **IndexedDB** in the left sidebar
-4. Right-click on **CaptainClawWebAssets**
-5. Select **Delete "CaptainClawWebAssets"**
+4. Right-click on **ClawWebAssets**
+5. Select **Delete "ClawWebAssets"**
 6. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
 **Safari:**
 
 1. Press `Option + Command + C` to open Web Inspector
 2. Go to **Storage** tab
-3. Select **IndexedDB** → **CaptainClawWebAssets**
+3. Select **IndexedDB** → **ClawWebAssets**
 4. Click the trash icon to delete
 5. Refresh the page - you'll be prompted to upload CLAW.REZ again
 
@@ -39,7 +39,7 @@ If you need to re-upload CLAW.REZ or encounter storage issues, you can clear the
 3. Paste this command and press Enter:
 
    ```javascript
-   indexedDB.deleteDatabase('CaptainClawWebAssets')
+   indexedDB.deleteDatabase('ClawWebAssets')
    ```
 
 4. Refresh the page - you'll be prompted to upload CLAW.REZ again

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "captain-claw-web",
+  "name": "claw-web",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/_deploy-lib.sh
+++ b/scripts/_deploy-lib.sh
@@ -3,8 +3,8 @@
 # Sourced by deploy-prod.sh and deploy-staging.sh. Not meant to run standalone.
 #
 # gh-pages layout on origin:
-#   /            -> production (served at https://arthurboss.github.io/captain-claw-web/)
-#   /staging/    -> staging    (served at .../captain-claw-web/staging/)
+#   /            -> production (served at https://arthurboss.github.io/claw-web/)
+#   /staging/    -> staging    (served at .../claw-web/staging/)
 # Both live on the single origin/gh-pages branch. deploy-prod excludes staging/
 # from its --delete; deploy-staging scopes its rsync target to staging/ only.
 

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Deploy Build_Release/ to the ROOT of origin/gh-pages == PRODUCTION.
-#   https://arthurboss.github.io/captain-claw-web/
+#   https://arthurboss.github.io/claw-web/
 #
 # Safe against staging: the rsync --delete explicitly EXCLUDES staging/, so a
 # production deploy never touches the /staging/ subdirectory.
@@ -20,8 +20,8 @@ log "Syncing Build_Release/ -> gh-pages root (preserving staging/) ..."
 rsync -a --delete --exclude="staging/" "${RSYNC_EXCLUDES[@]}" \
   "$BUILD_DIR/" "$WORKTREE/"
 
-# GitHub Pages serves / from index.html; the game entry point is captain-claw-web.html.
-cp "$BUILD_DIR/captain-claw-web.html" "$WORKTREE/index.html"
+# GitHub Pages serves / from index.html; the game entry point is claw-web.html.
+cp "$BUILD_DIR/claw-web.html" "$WORKTREE/index.html"
 
 commit_and_push "$MSG"
-log "Production live at: https://arthurboss.github.io/captain-claw-web/"
+log "Production live at: https://arthurboss.github.io/claw-web/"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Deploy Build_Release/ to the /staging/ subdirectory of origin/gh-pages.
-#   https://arthurboss.github.io/captain-claw-web/staging/
+#   https://arthurboss.github.io/claw-web/staging/
 #
 # Safe against production: the rsync --delete target is scoped to the staging/
 # subdirectory only, so it can never remove or modify any root (production)
 # file. The PWA uses relative paths (manifest scope "./", SW registers with
 # scope "./"), so the staging service worker registers with scope
-# /captain-claw-web/staging/ and cannot cache or interfere with production's
+# /claw-web/staging/ and cannot cache or interfere with production's
 # root-scoped SW. staging/sw-control.json is its own kill-switch copy.
 #
 # Usage:  scripts/deploy-staging.sh ["commit message"]
@@ -27,7 +27,7 @@ rsync -a --delete "${RSYNC_EXCLUDES[@]}" \
   "$BUILD_DIR/" "$WORKTREE/staging/"
 
 # Entry point for /staging/ (mirrors how root uses index.html).
-cp "$BUILD_DIR/captain-claw-web.html" "$WORKTREE/staging/index.html"
+cp "$BUILD_DIR/claw-web.html" "$WORKTREE/staging/index.html"
 
 commit_and_push "$MSG"
-log "Staging live at: https://arthurboss.github.io/captain-claw-web/staging/"
+log "Staging live at: https://arthurboss.github.io/claw-web/staging/"

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,7 @@ export default defineConfig({
     outDir: resolve(import.meta.dirname, 'dist'),
     emptyOutDir: true,
     rollupOptions: {
-      input: resolve(import.meta.dirname, 'Build_Release/captain-claw-web.html'),
+      input: resolve(import.meta.dirname, 'Build_Release/claw-web.html'),
     },
     assetsInlineLimit: 0,
   },
@@ -39,7 +39,7 @@ export default defineConfig({
       name: 'rewrite-root',
       configureServer(server) {
         server.middlewares.use((req, _res, next) => {
-          if (req.url === '/') req.url = '/captain-claw-web.html';
+          if (req.url === '/') req.url = '/claw-web.html';
           next();
         });
       },


### PR DESCRIPTION
- Rename project brand from Captain Claw Web to Claw Web (distinct from the copyrighted 1997 title)
- Add unofficial fan-project disclaimer (README + on-page upload screen)
- Rename HTML entry captain-claw-web.html → claw-web.html, update all references
- Storage identifiers: IndexedDB ClawWebAssets, localStorage claw-web:saves
- Chained one-time migration walks every prior name (CaptainClawWeb* then OpenClaw*) newest-first, so users from ANY version keep uploads and saves with no re-upload
- Rebuilt WASM: SaveBridge.cpp + VGetGameTitle() use new identifiers
- SW cache version bumped v3 → v4 to force fresh assets on user next load
- Keeps Captain Claw (1997) only where it refers to the original game, single upstream OpenClaw credit in README

Ready for merge and production deploy at new /claw-web/ URL.