### PR TITLE
chore: bump SW cache v4->v5 and document version bump rule

### DIFF
--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -7,7 +7,7 @@
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.
-const CACHE_VERSION = "v4";
+const CACHE_VERSION = "v5";
 const SCOPE_PATH = (function () {
   try {
     return new URL(self.registration.scope).pathname;
@@ -40,6 +40,7 @@ const SHELL_ASSETS = [
   "./favicon.ico",
   "./favicon-16x16.png",
   "./favicon-32x32.png",
+  "./preview.png",
 ];
 
 // On install: cache the app shell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ Deploys are manual via `scripts/`. Both environments share the `gh-pages` branch
 
 **Default workflow:** deploy every new branch to **staging first** (safe — never touches prod), test on a real device, then merge and run `deploy-prod.sh` to promote. Skip only for deploy-only/non-visual changes.
 
+> **SW cache version rule:** any PR that modifies a file listed in `SHELL_ASSETS` in `sw.js` (i.e. `claw-web.html`, `game-init.js`, any `.js` bridge, `site.webmanifest`, icons, or `preview.png`) **must** bump `CACHE_VERSION` in `sw.js` (e.g. `v5` -> `v6`). Without a bump, returning users with a cached SW will not receive the updated files. Also ensure any new `Build_Release/` file served to the browser is added to `SHELL_ASSETS`.
+
 **Env isolation** (prod + staging share one origin, so storage is scoped deliberately):
 
 - **SW cache** named per scope (`openclaw::<scope>::<version>`) — a version bump in one env can't delete the other's cache; kill-switch teardown is scoped too.

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -327,7 +327,7 @@ Potential improvements for even better performance:
 - [x] Compress metadata XMLs with gzip (✓ Implemented - 79% size reduction)
 - [ ] Preload next level's metadata while playing current level
 - [ ] Implement progressive asset loading (low-res → high-res)
-- [ ] Add service worker for offline play
+- [x] Add service worker for offline play (✓ Implemented - `sw.js` caches shell assets; bump `CACHE_VERSION` in `sw.js` whenever a file in `SHELL_ASSETS` changes)
 - [ ] Use WebAssembly SIMD for faster resource decompression
 
 ## References


### PR DESCRIPTION
- Bump `CACHE_VERSION` `v4`->`v5` so returning users with a cached SW receive the updated `claw-web.html`, `game-init.js`, and `site.webmanifest` from PR #72
- Add `preview.png` to `SHELL_ASSETS` so it is cached for offline PWA use
- Add SW cache version rule to `CLAUDE.md`: any PR touching a `SHELL_ASSETS` file must bump `CACHE_VERSION`, and new `Build_Release/` files must be added to `SHELL_ASSETS`
- Mark service worker TODO as done in `ARCHITECTURE.md` with a note on the bump requirement