### PR TITLE
fix: resolve first-upload failure on iOS PWA

### DIFF
--- a/Build_Release/asset-loader.js
+++ b/Build_Release/asset-loader.js
@@ -41,6 +41,16 @@ const REZ_VALID_SIGNATURES = ['RezMgr Version 1', 'WinRez 2.4'];
 const REZ_MIN_SIZE = 100 * 1024 * 1024; // ~100MB; real files are ~113MB
 const REZ_MAX_SIZE = 130 * 1024 * 1024; // generous upper bound
 
+function showUploadError(message) {
+  const el = document.getElementById('uploadError');
+  if (el) { el.textContent = message; el.style.display = 'block'; }
+}
+
+function clearUploadError() {
+  const el = document.getElementById('uploadError');
+  if (el) { el.textContent = ''; el.style.display = 'none'; }
+}
+
 function rejectRezFile(message) {
   const fileInput = document.getElementById('clawRezFile');
   const uploadBtn = document.getElementById('uploadBtn');
@@ -50,10 +60,11 @@ function rejectRezFile(message) {
   if (uploadBtn) uploadBtn.disabled = true;
   if (drop) drop.classList.remove('has-file');
   if (name) name.textContent = '';
-  alert(message);
+  showUploadError(message);
 }
 
 function acceptRezFile(file) {
+  clearUploadError();
   const uploadBtn = document.getElementById('uploadBtn');
   const drop = document.getElementById('fileDrop');
   const name = document.getElementById('fileDropName');
@@ -199,6 +210,16 @@ async function uploadClawRez() {
     window.prewarmAudioContext();
   }
 
+  // Request durable storage on first upload. On iOS PWA the system may show
+  // a permission prompt on the very first write; calling persist() here
+  // (inside a user gesture) ensures the grant happens before we start writing
+  // so the write doesn't silently fail.
+  if (navigator.storage && navigator.storage.persist) {
+    navigator.storage.persist().catch(() => {});
+  }
+
+  clearUploadError();
+
   // Show progress UI
   document.getElementById('uploadArea').style.display = 'none';
   const progressDiv = document.getElementById('uploadProgress');
@@ -283,7 +304,7 @@ async function uploadClawRez() {
       failMsg += '\n\nTip: private / incognito browsing often blocks local '
                + 'storage. Try again in a normal browser window.';
     }
-    alert(failMsg);
+    showUploadError(failMsg);
 
     // Reset UI
     progressDiv.style.display = 'none';

--- a/Build_Release/claw-web.html
+++ b/Build_Release/claw-web.html
@@ -706,6 +706,7 @@
             <input type="file" id="clawRezFile" accept=".REZ,.rez" onchange="validateClawRezFile()" />
           </label>
           <button class="btn btn-primary" id="uploadBtn" onclick="uploadClawRez()" disabled>Upload CLAW.REZ</button>
+          <p id="uploadError" style="display:none;color:#e23b2e;margin-top:0.75rem;font-size:0.9em;white-space:pre-wrap;"></p>
         </div>
 
         <div id="uploadProgress" style="display: none;">

--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -7,7 +7,7 @@
 // share the origin's Cache Storage, and a version bump in one environment
 // would run activate -> caches.keys() -> delete the OTHER environment's cache.
 // registration.scope is the source of truth; fall back to the SW's own path.
-const CACHE_VERSION = "v5";
+const CACHE_VERSION = "v6";
 const SCOPE_PATH = (function () {
   try {
     return new URL(self.registration.scope).pathname;


### PR DESCRIPTION
On a freshly installed iOS PWA, the first CLAW.REZ upload silently fails with a black screen blink and no error shown.

Two root causes:

- **iOS storage quota prompt suppressed:** WebKit fires a storage permission dialog behind the fullscreen PWA which auto-dismisses, causing the IndexedDB write to fail silently. Fix: call `navigator.storage.persist()` inside the upload button click handler (a user gesture) before writing, so the grant is processed before the write begins.
- **`alert()` suppressed in iOS fullscreen PWA mode:** errors were swallowed silently. Fix: replace all upload-flow `alert()` calls with an inline `#uploadError` element inside the upload card — always visible regardless of PWA display mode.

SW bumped `v5`->`v6` (`claw-web.html` and `asset-loader.js` are in `SHELL_ASSETS`).