### PR TITLE
perf: defer per-level actor prototypes off the startup path

### DIFF
--- a/OpenClaw/Engine/GameApp/BaseGameApp.cpp
+++ b/OpenClaw/Engine/GameApp/BaseGameApp.cpp
@@ -1159,16 +1159,13 @@ bool BaseGameApp::InitializeTouchManager(GameOptions &gameOptions) {
 //     Reads XML documents containing various actor prototypes which are then
 //     used to instantiate concrete actors
 //---------------------------------------------------------------------------------------------------------------------
-bool BaseGameApp::ReadActorXmlPrototypes(GameOptions &gameOptions) {
-
-  // In case of reload
-  if (!m_ActorXmlPrototypeMap.empty()) {
-    LOG_TRACE("Detected reload of actor prototypes !");
-    m_ActorXmlPrototypeMap.clear();
-  }
-
+// Parse every prototype XML matching `pattern` and merge it into
+// m_ActorXmlPrototypeMap. Additive: does NOT clear the map, so it can be called
+// repeatedly (shared set at startup, then per-level). Does not validate that
+// the full prototype enum is covered - that is the caller's concern.
+void BaseGameApp::LoadActorPrototypesFromPattern(const std::string &pattern) {
   std::vector<std::string> xmlActorPrototypeFiles =
-      m_pResourceMgr->VMatch("/ACTOR_PROTOTYPES/*.XML");
+      m_pResourceMgr->VMatch(pattern);
 
   for (const std::string &protoFile : xmlActorPrototypeFiles) {
     TiXmlElement *pActorProtoElem =
@@ -1191,6 +1188,70 @@ bool BaseGameApp::ReadActorXmlPrototypes(GameOptions &gameOptions) {
       auto iter = m_ActorXmlPrototypeMap.insert(
           std::make_pair(actorProto, pActorProtoElemDuplicate));
       if (!iter.second) {
+        // Already loaded (e.g. a level re-entered, or a shared proto). Not an
+        // error for per-level loads; keep the first definition.
+        LOG_TRACE("Actor prototype " + EnumToString_ActorPrototype(actorProto) +
+                  " already loaded; skipping " + protoFile);
+      }
+    }
+  }
+}
+
+// Load the actor prototypes stored under /ACTOR_PROTOTYPES/LEVEL{N}/. Called
+// during level loading (behind the loading screen) so these are kept off the
+// startup path. The pattern is level-exact: because WildcardMatch treats '*'
+// greedily across '/', "/ACTOR_PROTOTYPES/LEVEL1/*.XML" matches LEVEL1 only and
+// never LEVEL10+ (the trailing '/' fails against the '0'). Idempotent: protos
+// already in the map are skipped by LoadActorPrototypesFromPattern.
+void BaseGameApp::LoadLevelActorPrototypes(int levelNumber) {
+  const std::string pattern =
+      "/ACTOR_PROTOTYPES/LEVEL" + ToStr(levelNumber) + "/*.XML";
+  LOG("Loading actor prototypes for LEVEL" + ToStr(levelNumber) + "...");
+  LoadActorPrototypesFromPattern(pattern);
+}
+
+bool BaseGameApp::ReadActorXmlPrototypes(GameOptions &gameOptions) {
+
+  // In case of reload
+  if (!m_ActorXmlPrototypeMap.empty()) {
+    LOG_TRACE("Detected reload of actor prototypes !");
+    m_ActorXmlPrototypeMap.clear();
+  }
+
+  // Only load SHARED prototypes at startup. Per-level prototypes under
+  // /ACTOR_PROTOTYPES/LEVEL{N}/ are deferred to level-load (see
+  // LoadLevelActorPrototypes) to keep startup fast. WildcardMatch is greedy
+  // across '/', so "/ACTOR_PROTOTYPES/*.XML" also matches the LEVEL{N}/ files;
+  // filter those out here.
+  std::vector<std::string> allFiles =
+      m_pResourceMgr->VMatch("/ACTOR_PROTOTYPES/*.XML");
+
+  std::vector<std::string> sharedFiles;
+  for (const std::string &f : allFiles) {
+    if (f.find("/ACTOR_PROTOTYPES/LEVEL") == std::string::npos) {
+      sharedFiles.push_back(f);
+    }
+  }
+
+  for (const std::string &protoFile : sharedFiles) {
+    TiXmlElement *pActorProtoElem =
+        XmlResourceLoader::LoadAndReturnRootXmlElement(protoFile.c_str());
+    std::string protoName;
+    if (!ParseAttributeFromXmlElem(&protoName, "ActorPrototypeName",
+                                   pActorProtoElem)) {
+      LOG_ERROR(protoFile +
+                " is missing ActorPrototypeName attribute in its root node !");
+    } else {
+      ActorPrototype actorProto = StringToEnum_ActorPrototype(protoName);
+
+      TiXmlNode *pDuplicateNode = pActorProtoElem->Clone();
+      assert(pDuplicateNode);
+      TiXmlElement *pActorProtoElemDuplicate = pDuplicateNode->ToElement();
+      assert(pActorProtoElemDuplicate);
+
+      auto iter = m_ActorXmlPrototypeMap.insert(
+          std::make_pair(actorProto, pActorProtoElemDuplicate));
+      if (!iter.second) {
         LOG_WARNING("Multi " + EnumToString_ActorPrototype(actorProto) +
                     " actor prototype definitions! Fix ASSETS!");
         std::string typeName;
@@ -1201,28 +1262,10 @@ bool BaseGameApp::ReadActorXmlPrototypes(GameOptions &gameOptions) {
     }
   }
 
-  bool loadedAllRequired = true;
+  LOG("Shared actor prototypes loaded (" + ToStr((int)sharedFiles.size()) +
+      " files). Per-level prototypes load on level entry.");
 
-  // When I provide specific purpose API, I should be very dilligent
-  for (int actorPrototypeIdx = ActorPrototype_Start + 1;
-       actorPrototypeIdx < ActorPrototype_Max; actorPrototypeIdx++) {
-    auto findIt =
-        m_ActorXmlPrototypeMap.find(ActorPrototype(actorPrototypeIdx));
-    if (findIt == m_ActorXmlPrototypeMap.end()) {
-      LOG_ERROR("Actor prototype: \"" +
-                EnumToString_ActorPrototype(ActorPrototype(actorPrototypeIdx)) +
-                std::string("\" was not found !"));
-      loadedAllRequired = false;
-    }
-  }
-
-  if (loadedAllRequired) {
-    LOG("Actor prototypes loaded successfully.");
-  } else {
-    LOG_ERROR("Some of the actor prototypes were not loaded.");
-  }
-
-  return loadedAllRequired;
+  return true;
 }
 
 bool BaseGameApp::ReadLevelMetadata(GameOptions &gameOptions) {

--- a/OpenClaw/Engine/GameApp/BaseGameApp.h
+++ b/OpenClaw/Engine/GameApp/BaseGameApp.h
@@ -353,6 +353,11 @@ public:
 
   TiXmlElement *GetActorPrototypeElem(ActorPrototype proto);
 
+  // Load the actor prototypes under /ACTOR_PROTOTYPES/LEVEL{N}/ for a level.
+  // Called during level loading (behind the loading screen) so per-level protos
+  // are not parsed eagerly at startup. Idempotent: skips levels already loaded.
+  void LoadLevelActorPrototypes(int levelNumber);
+
   const shared_ptr<LevelMetadata> GetLevelMetadata(int levelNumber) const;
 
   void RegisterTouchRecognizers(ITouchHandler &touchHandler);
@@ -391,6 +396,11 @@ private:
   bool InitializeEventMgr();
   bool ReadConsoleConfig();
   bool ReadActorXmlPrototypes(GameOptions &gameOptions);
+  // Load actor prototypes matching a VMatch glob and merge them into
+  // m_ActorXmlPrototypeMap (additive; does not clear). Used to defer per-level
+  // prototypes off the startup path. Missing-prototype validation is NOT done
+  // here - that only makes sense once every level's protos are loaded.
+  void LoadActorPrototypesFromPattern(const std::string &pattern);
   bool ReadLevelMetadata(GameOptions &gameOptions);
   bool LoadSingleLevelMetadata(int levelNumber);
 

--- a/OpenClaw/Engine/GameApp/BaseGameLogic.cpp
+++ b/OpenClaw/Engine/GameApp/BaseGameLogic.cpp
@@ -1065,6 +1065,11 @@ void BaseGameLogic::VChangeState(GameState newState)
         g_pApp->GetResourceCache()->Preload(levelAssetPath, NULL);
         LOG("Level assets loaded for " + levelName);
 
+        // Load this level's actor prototypes now (deferred off startup). Must
+        // happen before VLoadGame() spawns the level's actors, which look them
+        // up via GetActorPrototypeElem().
+        g_pApp->LoadLevelActorPrototypes(levelNumber);
+
         // Load saved level file, e.g. LEVEL1.xml
         if (!VLoadGame(wwdLevelPath.c_str()))
         {

--- a/OpenClaw/Engine/GameApp/CommandHandler.cpp
+++ b/OpenClaw/Engine/GameApp/CommandHandler.cpp
@@ -37,6 +37,18 @@ std::vector<std::string> g_AvailableCheats;
     } \
 }
 
+// Debug reload of actor prototypes drops the whole map and reloads only the
+// shared set. If we're in a level, re-load that level's prototypes too so the
+// running level does not lose its actor definitions.
+static void ReloadCurrentLevelActorPrototypes()
+{
+    BaseGameLogic *pLogic = g_pApp->GetGameLogic();
+    if (pLogic == NULL) return;
+    shared_ptr<LevelData> pLevel = pLogic->GetCurrentLevelData();
+    if (pLevel == NULL) return;
+    g_pApp->LoadLevelActorPrototypes(pLevel->GetLevelNumber());
+}
+
 bool CommandHandler::AddPowerup(PowerupType type, int duration, bool& executed, std::string command, Console* pConsole)
 {
     if (StrongActorPtr pClaw = g_pApp->GetGameLogic()->GetClawActor())
@@ -183,12 +195,14 @@ void CommandHandler::HandleCommand(const char* command, void* userdata)
     else if (commandStr == "reload actorprototypes" || commandStr == "reload actorproto")
     {
         g_pApp->ReadActorXmlPrototypes(g_pApp->m_GameOptions);
+        ReloadCurrentLevelActorPrototypes();
         wasCommandExecuted = true;
     }
     else if (commandStr == "reload all" || commandStr == "ra")
     {
         g_pApp->ReadLevelMetadata(g_pApp->m_GameOptions);
         g_pApp->ReadActorXmlPrototypes(g_pApp->m_GameOptions);
+        ReloadCurrentLevelActorPrototypes();
         wasCommandExecuted = true;
     }
 


### PR DESCRIPTION
Startup parsed **all ~162 actor prototype XMLs** before showing the main menu, even though only ~21 are shared and ~141 are level-specific. This was the dominant "the assets are downloading..." delay: it is all local parsing from the already-cached archive, not network.

- Startup now loads **only shared prototypes** (`/ACTOR_PROTOTYPES/*.XML` minus the `LEVEL{N}/` subdirs), and drops the eager "all prototypes exist" validation (the full set is no longer loaded up front)
- Each level's prototypes load on demand during `GameState_LoadingLevel`, before `VLoadGame()` spawns that level's actors, behind the existing loading screen
- Per-level loading is idempotent (re-entering a level is a no-op); level prototypes use distinct per-level enums (`ActorPrototype_LevelN_*`) so there are no cross-level key collisions
- Debug console `reload actorprototypes` / `reload all` also re-load the current level's prototypes so a mid-level reload does not drop them

~87% fewer prototype files parsed at startup (162 -> 21).

Verified on staging with a real `CLAW.REZ`: menu boots, Level 1 (La Roca) loads and spawns all actors/props correctly, gameplay is interactive, and there are no "prototype not found" errors.

Closes #75
