### PR TITLE
fix: defer SW activation to prevent mid-session interruption

### DIFF
--- a/Build_Release/sw.js
+++ b/Build_Release/sw.js
@@ -66,10 +66,10 @@ self.addEventListener("install", (event) => {
         // Use addAll to fail fast if any asset is missing
         return cache.addAll(SHELL_ASSETS);
       })
-      .then(() => {
-        // Force waiting service worker to become active immediately
-        return self.skipWaiting();
-      })
+      // Intentionally NOT calling skipWaiting() — the new SW waits until all tabs
+      // using the old SW are closed. This prevents mid-session page reloads that
+      // can interrupt IndexedDB transactions (e.g., CLAW.REZ upload). Standard safe
+      // update behavior: users get the new SW on next PWA launch, not mid-session.
   );
 });
 


### PR DESCRIPTION
Remove `skipWaiting()` from the SW install handler. The new SW now waits until all tabs using the old SW are closed before taking over, instead of activating immediately.

This prevents mid-session page reloads that interrupt IndexedDB transactions — specifically the CLAW.REZ upload, which was failing on iOS PWA because the page was reloading while the transaction was in flight.

Users get the new SW on the next PWA launch (when they close and reopen), which is the standard safe update behavior and acceptable for a game.